### PR TITLE
Add translate function to AffineTransform3D for coder convenience

### DIFF
--- a/src/main/java/net/imglib2/realtransform/AffineTransform3D.java
+++ b/src/main/java/net/imglib2/realtransform/AffineTransform3D.java
@@ -658,6 +658,43 @@ public class AffineTransform3D implements AffineGet, AffineSet, Concatenable< Af
 	{
 		a.scale( s );
 	}
+	
+	/**
+	 * Translation 
+	 * 
+	 * @param translationVector
+	 * 				vector describing the translation
+	 * 	
+	 */
+	public void translate(double... translationVector)
+	{
+		a.m03 += translationVector[0];
+		a.m13 += translationVector[1];
+		a.m23 += translationVector[2];
+	}
+	
+	/**
+	 * Initialize the translation with a given vector
+	 * 
+	 * @return
+	 * 		vector with 3 elements describing the translation
+	 */
+	public double[] getTranslation()
+	{
+		return new double[] {a.m03, a.m13, a.m23};
+	}
+	
+	/**
+	 * Initialize the translation with a given vector
+	 * 
+	 * @param translationVector
+	 */
+	public void setTranslation(double... translationVector)
+	{
+		a.m03 = translationVector[0];
+		a.m13 = translationVector[1];
+		a.m23 = translationVector[2];
+	}
 
 	/**
 	 * Set to identity transform

--- a/src/test/java/net/imglib2/realtransform/AffineTransform3DTest.java
+++ b/src/test/java/net/imglib2/realtransform/AffineTransform3DTest.java
@@ -135,5 +135,39 @@ public class AffineTransform3DTest
 			assertArrayEquals( dR.getRowPackedCopy(), affine.getRowPackedCopy(), 0.001 );
 		}
 	}
+	
+	@Test
+	public void testTranslation()
+	{
+		double[] translation = new double[]{rnd.nextDouble(), rnd.nextDouble(), rnd.nextDouble()};
+		double[] inverseTranslation = new double[]{-translation[0], -translation[1], -translation[2]};
+		
+		final AffineTransform3D affine = new AffineTransform3D();
+		affine.set(
+				rnd.nextDouble(), rnd.nextDouble(), rnd.nextDouble(), translation[0],
+				rnd.nextDouble(), rnd.nextDouble(), rnd.nextDouble(), translation[1],
+				rnd.nextDouble(), rnd.nextDouble(), rnd.nextDouble(), translation[2] );
+		
+		AffineTransform3D toBeOrigin = affine.copy();
+		double[] translationFromOrigin = affine.getTranslation();
+		
+		//Move to origin and test
+		toBeOrigin.translate(inverseTranslation);
+		assertArrayEquals( toBeOrigin.getTranslation(), new double[]{0, 0, 0}, 0.001 );
+		
+		//Move to origin the easy way
+		toBeOrigin = affine.copy();
+		toBeOrigin.setTranslation(0, 0, 0);
+		assertArrayEquals( toBeOrigin.getTranslation(), new double[]{0, 0, 0}, 0.001 );
+		
+		//Move back to initial position
+		final AffineTransform3D backToOriginal = toBeOrigin.copy();
+		backToOriginal.translate(translationFromOrigin);
+
+		assertArrayEquals( backToOriginal.getRowPackedCopy(), affine.getRowPackedCopy(), 0.001 );
+		
+		
+		
+	}
 
 }


### PR DESCRIPTION
If there is a scale and a rotate function, there should also be a translate function. If there is a translate function, there should also be a setTranslation and getTranslation function...