### PR TITLE
RealTransformRealRandomAccessible: add getters for target and transform

### DIFF
--- a/src/main/java/net/imglib2/realtransform/RealTransformRealRandomAccessible.java
+++ b/src/main/java/net/imglib2/realtransform/RealTransformRealRandomAccessible.java
@@ -140,5 +140,23 @@ public class RealTransformRealRandomAccessible< T, R extends RealTransform > imp
 	{
 		return realRandomAccess();
 	}
+	
+	/**
+	 * @return target {@link RealRandomAccessible}
+	 */
+	public RealRandomAccessible< T > getTarget()
+	{
+		return target;
+	}
+
+	/**
+	 * @return transform applied to target
+	 */
+	public R getTransform()
+	{
+		return transform;
+	}
+	
+	
 
 }

--- a/src/main/java/net/imglib2/realtransform/RealTransformRealRandomAccessible.java
+++ b/src/main/java/net/imglib2/realtransform/RealTransformRealRandomAccessible.java
@@ -140,7 +140,7 @@ public class RealTransformRealRandomAccessible< T, R extends RealTransform > imp
 	{
 		return realRandomAccess();
 	}
-	
+
 	/**
 	 * @return target {@link RealRandomAccessible}
 	 */
@@ -156,7 +156,4 @@ public class RealTransformRealRandomAccessible< T, R extends RealTransform > imp
 	{
 		return transform;
 	}
-	
-	
-
 }


### PR DESCRIPTION
this is useful for decomposition of RealTransformRealRandomAccessibles into its individual parts (e.g. for serialization).