### PR TITLE
Fix AffineTransfrom3D Inverse Transform Bug

### DIFF
--- a/src/main/java/net/imglib2/realtransform/AffineTransform3D.java
+++ b/src/main/java/net/imglib2/realtransform/AffineTransform3D.java
@@ -706,6 +706,10 @@ public class AffineTransform3D implements AffineGet, AffineSet, Concatenable< Af
 		a.m03 = translationVector[0];
 		a.m13 = translationVector[1];
 		a.m23 = translationVector[2];
+
+		invert();
+		updateDs();
+		inverse.updateDs();
 	}
 
 	/**

--- a/src/main/java/net/imglib2/realtransform/AffineTransform3D.java
+++ b/src/main/java/net/imglib2/realtransform/AffineTransform3D.java
@@ -646,6 +646,10 @@ public class AffineTransform3D implements AffineGet, AffineSet, Concatenable< Af
 			a.rotateZ( dcos, dsin );
 			break;
 		}
+
+		invert();
+		updateDs();
+		inverse.updateDs();
 	}
 
 	/**
@@ -657,6 +661,10 @@ public class AffineTransform3D implements AffineGet, AffineSet, Concatenable< Af
 	public void scale( final double s )
 	{
 		a.scale( s );
+
+		invert();
+		updateDs();
+		inverse.updateDs();
 	}
 	
 	/**
@@ -671,6 +679,10 @@ public class AffineTransform3D implements AffineGet, AffineSet, Concatenable< Af
 		a.m03 += translationVector[0];
 		a.m13 += translationVector[1];
 		a.m23 += translationVector[2];
+
+		invert();
+		updateDs();
+		inverse.updateDs();
 	}
 	
 	/**

--- a/src/test/java/net/imglib2/realtransform/AffineTransform3DTest.java
+++ b/src/test/java/net/imglib2/realtransform/AffineTransform3DTest.java
@@ -104,8 +104,9 @@ public class AffineTransform3DTest
 
 			dR.concatenate( affine );
 			affine.rotate( axis, d );
-			
+
 			assertArrayEquals( dR.getRowPackedCopy(), affine.getRowPackedCopy(), 0.001 );
+			assertArrayEquals( dR.inverse().getRowPackedCopy(), affine.inverse().getRowPackedCopy(), 0.001 );
 		}
 	}
 	
@@ -131,8 +132,9 @@ public class AffineTransform3DTest
 			
 			dR.concatenate( affine );
 			affine.scale( s );
-			
+
 			assertArrayEquals( dR.getRowPackedCopy(), affine.getRowPackedCopy(), 0.001 );
+			assertArrayEquals( dR.inverse().getRowPackedCopy(), affine.inverse().getRowPackedCopy(), 0.001 );
 		}
 	}
 	
@@ -154,7 +156,8 @@ public class AffineTransform3DTest
 		//Move to origin and test
 		toBeOrigin.translate(inverseTranslation);
 		assertArrayEquals( toBeOrigin.getTranslation(), new double[]{0, 0, 0}, 0.001 );
-		
+		assertArrayEquals( toBeOrigin.inverse().getTranslation(), new double[]{ 0, 0, 0 }, 0.001 );
+
 		//Move to origin the easy way
 		toBeOrigin = affine.copy();
 		toBeOrigin.setTranslation(0, 0, 0);
@@ -165,9 +168,7 @@ public class AffineTransform3DTest
 		backToOriginal.translate(translationFromOrigin);
 
 		assertArrayEquals( backToOriginal.getRowPackedCopy(), affine.getRowPackedCopy(), 0.001 );
-		
-		
-		
+		assertArrayEquals( backToOriginal.inverse().getRowPackedCopy(), affine.inverse().getRowPackedCopy(), 0.001 );
 	}
 
 }

--- a/src/test/java/net/imglib2/realtransform/AffineTransform3DTest.java
+++ b/src/test/java/net/imglib2/realtransform/AffineTransform3DTest.java
@@ -162,7 +162,8 @@ public class AffineTransform3DTest
 		toBeOrigin = affine.copy();
 		toBeOrigin.setTranslation(0, 0, 0);
 		assertArrayEquals( toBeOrigin.getTranslation(), new double[]{0, 0, 0}, 0.001 );
-		
+		assertArrayEquals( toBeOrigin.inverse().getTranslation(), new double[]{ 0, 0, 0 }, 0.001 );
+
 		//Move back to initial position
 		final AffineTransform3D backToOriginal = toBeOrigin.copy();
 		backToOriginal.translate(translationFromOrigin);


### PR DESCRIPTION
Hello!

I noticed that after calling `rotate(..)`, `scale(...)`, or `translate(...)` on an `AffineTransform3D` the corresponding inverse transform matrix was not being updated. These changes add code to update the inverse transform after those method calls, and adds tests to ensure the inverse is updated. 

Please feel free to let me know if there are any issues with these commits.

Thanks!