### PR TITLE
deprecate float[]

### DIFF
--- a/src/main/java/net/imglib2/realtransform/DeformationFieldTransform.java
+++ b/src/main/java/net/imglib2/realtransform/DeformationFieldTransform.java
@@ -11,13 +11,13 @@
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- * 
+ *
  * 1. Redistributions of source code must retain the above copyright notice,
  *    this list of conditions and the following disclaimer.
  * 2. Redistributions in binary form must reproduce the above copyright notice,
  *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -45,7 +45,7 @@ import net.imglib2.view.Views;
 
 /**
  * An <em>n</em>-dimensional deformation field.
- * <p> 
+ * <p>
  * Wraps a {@link RandomAccessibleInterval} of dimensionality D+1 ("def")
  * and interprets it as a D-dimensional {@link RealTransform}.  The last
  * dimension of of the {@link RandomAccessibleInterval} must have at
@@ -53,8 +53,8 @@ import net.imglib2.view.Views;
  * <p>
  * The deformation field should be interpreted as a d-dimensional
  * vector field.  A source point is displaced by adding the vector
- * at that point the the source point's position. 
- * 
+ * at that point the the source point's position.
+ *
  * @author John Bogovic &lt;bogovicj@janelia.hhmi.org&gt;
  *
  */
@@ -67,12 +67,12 @@ public class DeformationFieldTransform<T extends RealType<T>> implements RealTra
 
 	private final int numDim;
 
-	public DeformationFieldTransform( RandomAccessibleInterval< T > def )
+	public DeformationFieldTransform( final RandomAccessibleInterval< T > def )
 	{
 		this( Views.interpolate( def, new NLinearInterpolatorFactory< T >() ) );
 	}
 
-	public DeformationFieldTransform( RealRandomAccessible< T > defFieldReal )
+	public DeformationFieldTransform( final RealRandomAccessible< T > defFieldReal )
 	{
 		this.defFieldReal = defFieldReal;
 		this.numDim = defFieldReal.numDimensions() - 1;
@@ -92,14 +92,14 @@ public class DeformationFieldTransform<T extends RealType<T>> implements RealTra
 	}
 
 	@Override
-	public void apply( double[] source, double[] target )
+	public void apply( final double[] source, final double[] target )
 	{
-		for ( int d = 0; d < target.length; d++ )
+		for ( int d = 0; d < numDim; d++ )
 			defFieldAccess.setPosition( source[ d ], d );
 
 		defFieldAccess.setPosition( 0.0, numDim );
 
-		System.arraycopy( source, 0, target, 0, source.length );
+		System.arraycopy( source, 0, target, 0, numDim );
 		for ( int d = 0; d < numDim; d++ )
 		{
 			target[ d ] += defFieldAccess.get().getRealDouble();
@@ -108,25 +108,9 @@ public class DeformationFieldTransform<T extends RealType<T>> implements RealTra
 	}
 
 	@Override
-	public void apply( float[] source, float[] target )
+	public void apply( final RealLocalizable source, final RealPositionable target )
 	{
-		for ( int d = 0; d < target.length; d++ )
-			defFieldAccess.setPosition( source[ d ], d );
-
-		defFieldAccess.setPosition( 0.0, numDim );
-
-		System.arraycopy( source, 0, target, 0, source.length );
 		for ( int d = 0; d < numDim; d++ )
-		{
-			target[ d ] += defFieldAccess.get().getRealDouble();
-			defFieldAccess.fwd( numDim );
-		}
-	}
-
-	@Override
-	public void apply( RealLocalizable source, RealPositionable target )
-	{
-		for ( int d = 0; d < target.numDimensions(); d++ )
 			defFieldAccess.setPosition( source.getDoublePosition( d ), d );
 
 		defFieldAccess.setPosition( 0.0, numDim );

--- a/src/main/java/net/imglib2/realtransform/InvertibleRealTransform.java
+++ b/src/main/java/net/imglib2/realtransform/InvertibleRealTransform.java
@@ -11,13 +11,13 @@
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- * 
+ *
  * 1. Redistributions of source code must retain the above copyright notice,
  *    this list of conditions and the following disclaimer.
  * 2. Redistributions in binary form must reproduce the above copyright notice,
  *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -40,12 +40,12 @@ import net.imglib2.RealPositionable;
 /**
  * Invertible transformation from R<sup><em>n</em></sup> to R<sup><em>m</em>
  * </sup>.
- * 
+ *
  * <p>
  * Applying the transformation to a <em>n</em>-dimensional <em>source</em>
  * vector yields a <em>m</em>-dimensional <em>target</em> vector.
  * </p>
- * 
+ *
  * <p>
  * You can also
  * {@link InvertibleRealTransform#applyInverse(RealPositionable, RealLocalizable)
@@ -58,7 +58,7 @@ import net.imglib2.RealPositionable;
  * expected to leave all dimensions beyond <em>n</em>-1 in the source vector and
  * <em>m</em>-1 in the target vector unchanged.
  * </p>
- * 
+ *
  * @author Tobias Pietzsch
  * @author Stephan Saalfeld
  */
@@ -66,7 +66,7 @@ public interface InvertibleRealTransform extends RealTransform
 {
 	/**
 	 * Apply the inverse transform to a target vector to obtain a source vector.
-	 * 
+	 *
 	 * @param source
 	 *            set this to the source coordinates.
 	 * @param target
@@ -76,18 +76,35 @@ public interface InvertibleRealTransform extends RealTransform
 
 	/**
 	 * Apply the inverse transform to a target vector to obtain a source vector.
-	 * 
+	 *
 	 * @param source
 	 *            set this to the source coordinates.
 	 * @param target
 	 *            target coordinates.
+	 *
+	 * @deprecated Use double precision instead
 	 */
-	public void applyInverse( final float[] source, final float[] target );
+	@Deprecated
+	public default void applyInverse( final float[] source, final float[] target )
+	{
+		assert source.length >= numSourceDimensions() && target.length >= numTargetDimensions() : "Input dimensions too small.";
+
+		final double[] doubleSource = new double[ source.length ];
+		final double[] doubleTarget = new double[ target.length ];
+
+		for ( int d = 0; d < target.length; ++d )
+			doubleTarget[ d ] = target[ d ];
+
+		applyInverse( doubleSource, doubleTarget );
+
+		for ( int d = 0; d < source.length; ++d )
+			source[ d ] = ( float )doubleSource[ d ];
+	}
 
 	/**
 	 * Apply the inverse transform to a target {@link RealLocalizable} to obtain
 	 * a source {@link RealPositionable}.
-	 * 
+	 *
 	 * @param source
 	 *            set this to the source coordinates.
 	 * @param target
@@ -97,7 +114,7 @@ public interface InvertibleRealTransform extends RealTransform
 
 	/**
 	 * Get the inverse transform.
-	 * 
+	 *
 	 * @return the inverse transform
 	 */
 	public InvertibleRealTransform inverse();

--- a/src/main/java/net/imglib2/realtransform/RealTransform.java
+++ b/src/main/java/net/imglib2/realtransform/RealTransform.java
@@ -93,8 +93,25 @@ public interface RealTransform
 	 * @param target
 	 *            set this to the target coordinates, length must be {@code >=}
 	 *            {@link #numTargetDimensions()}
+	 *
+	 * @deprecated use double precision instead
 	 */
-	public void apply( final float[] source, final float[] target );
+	@Deprecated
+	public default void apply( final float[] source, final float[] target )
+	{
+		assert source.length >= numSourceDimensions() && target.length >= numTargetDimensions() : "Input dimensions too small.";
+
+		final double[] doubleSource = new double[ source.length ];
+		final double[] doubleTarget = new double[ target.length ];
+
+		for ( int d = 0; d < source.length; ++d )
+			doubleSource[ d ] = source[ d ];
+
+		apply( doubleSource, doubleTarget );
+
+		for ( int d = 0; d < target.length; ++d )
+			target[ d ] = ( float )doubleTarget[ d ];
+	}
 
 	/**
 	 * Apply the {@link RealTransform} to a source {@link RealLocalizable} to

--- a/src/main/java/net/imglib2/realtransform/ThinplateSplineTransform.java
+++ b/src/main/java/net/imglib2/realtransform/ThinplateSplineTransform.java
@@ -46,57 +46,42 @@ import net.imglib2.RealPositionable;
  *
  * @author Stephan Saalfeld
  */
-public class ThinplateSplineTransform implements RealTransform {
-
+public class ThinplateSplineTransform implements RealTransform
+{
 	final private ThinPlateR2LogRSplineKernelTransform tps;
+
 	final private double[] a;
+
 	final private double[] b;
+
 	final private RealPoint rpa;
 
-	final static private ThinPlateR2LogRSplineKernelTransform init(
-			final double[][] p,
-			final double[][] q) {
-
+	final static private ThinPlateR2LogRSplineKernelTransform init( final double[][] p, final double[][] q )
+	{
 		assert p.length == q.length;
 
-		final ThinPlateR2LogRSplineKernelTransform tps =
-				new ThinPlateR2LogRSplineKernelTransform(p.length, p, q);
+		final ThinPlateR2LogRSplineKernelTransform tps = new ThinPlateR2LogRSplineKernelTransform( p.length, p, q );
 
 		return tps;
 	}
 
-	public ThinplateSplineTransform(final ThinPlateR2LogRSplineKernelTransform tps) {
-
+	public ThinplateSplineTransform( final ThinPlateR2LogRSplineKernelTransform tps )
+	{
 		this.tps = tps;
-		a = new double[tps.getNumDims()];
-		b = new double[a.length];
+		a = new double[ tps.getNumDims() ];
+		b = new double[ a.length ];
 		rpa = RealPoint.wrap( a );
 	}
 
-	public ThinplateSplineTransform(
-			final double[][] p,
-			final double[][] q) {
-
-		this(init(p, q));
-	}
-
-
-	@Override
-	public void apply(final double[] source, final double[] target) {
-
-		tps.apply(source, target);
+	public ThinplateSplineTransform( final double[][] p, final double[][] q )
+	{
+		this( init( p, q ) );
 	}
 
 	@Override
-	public void apply(final float[] source, final float[] target) {
-
-		for (int d = 0; d < a.length; ++d)
-			a[d] = source[d];
-
-		tps.apply(a, b);
-
-		for (int d = 0; d < b.length; ++d)
-			target[d] = (float)b[d];
+	public void apply( final double[] source, final double[] target )
+	{
+		tps.apply( source, target );
 	}
 
 	@Override
@@ -104,25 +89,26 @@ public class ThinplateSplineTransform implements RealTransform {
 	{
 		rpa.setPosition( source );
 		tps.apply( a, b );
-		target.setPosition( b );
+		for ( int d = 0; d < a.length; ++d )
+			target.setPosition( b[ d ], d );
 	}
 
 	@Override
-	public ThinplateSplineTransform copy() {
-
+	public ThinplateSplineTransform copy()
+	{
 		/* tps is stateless and constant and can therefore be reused */
-		return new ThinplateSplineTransform(tps);
+		return new ThinplateSplineTransform( tps );
 	}
 
 	@Override
-	public int numSourceDimensions() {
-
+	public int numSourceDimensions()
+	{
 		return tps.getNumDims();
 	}
 
 	@Override
-	public int numTargetDimensions() {
-
+	public int numTargetDimensions()
+	{
 		return tps.getNumDims();
 	}
 }


### PR DESCRIPTION
because everybody should use double[] precision and it costs time and work and makes implementations heavier when they try to efficiently support float[]