### PR TITLE
Allow to copy subinterfaces of InvertibleRealTransform

### DIFF
--- a/src/main/java/net/imglib2/realtransform/AffineGet.java
+++ b/src/main/java/net/imglib2/realtransform/AffineGet.java
@@ -65,4 +65,7 @@ public interface AffineGet extends InvertibleRealTransform, EuclideanSpace
 
 	@Override
 	AffineGet inverse();
+
+	@Override
+	AffineGet copy();
 }

--- a/src/main/java/net/imglib2/realtransform/ScaleAndTranslationGet.java
+++ b/src/main/java/net/imglib2/realtransform/ScaleAndTranslationGet.java
@@ -74,4 +74,7 @@ public interface ScaleAndTranslationGet extends AffineGet
 
 	@Override
 	ScaleAndTranslationGet inverse();
+
+	@Override
+	ScaleAndTranslationGet copy();
 }

--- a/src/main/java/net/imglib2/realtransform/ScaleGet.java
+++ b/src/main/java/net/imglib2/realtransform/ScaleGet.java
@@ -44,4 +44,7 @@ public interface ScaleGet extends ScaleAndTranslationGet
 {
 	@Override
 	ScaleGet inverse();
+
+	@Override
+	ScaleGet copy();
 }

--- a/src/main/java/net/imglib2/realtransform/TranslationGet.java
+++ b/src/main/java/net/imglib2/realtransform/TranslationGet.java
@@ -42,8 +42,9 @@ package net.imglib2.realtransform;
  */
 public interface TranslationGet extends ScaleAndTranslationGet
 {
-	
 	@Override
 	TranslationGet inverse();
-	
+
+	@Override
+	TranslationGet copy();
 }


### PR DESCRIPTION
Add overridden `copy()` methods to subinterfaces of `InvertibleRealTransform` to ensure the same return type.