### PR TITLE
Create general framework for iterative computation of transform inverses

### DIFF
--- a/src/main/java/net/imglib2/realtransform/DeformationFieldTransform.java
+++ b/src/main/java/net/imglib2/realtransform/DeformationFieldTransform.java
@@ -40,25 +40,26 @@ import net.imglib2.RealPositionable;
 import net.imglib2.RealRandomAccess;
 import net.imglib2.RealRandomAccessible;
 import net.imglib2.interpolation.randomaccess.NLinearInterpolatorFactory;
+import net.imglib2.realtransform.inverse.DifferentiableRealTransform;
 import net.imglib2.type.numeric.RealType;
 import net.imglib2.view.Views;
 
 /**
  * An <em>n</em>-dimensional deformation field.
  * <p>
- * Wraps a {@link RandomAccessibleInterval} of dimensionality D+1 ("def")
- * and interprets it as a D-dimensional {@link RealTransform}.  The last
- * dimension of of the {@link RandomAccessibleInterval} must have at
- * least D components.
+ * Wraps a {@link RandomAccessibleInterval} of dimensionality D+1 ("def") and
+ * interprets it as a D-dimensional {@link RealTransform}. The last dimension of
+ * of the {@link RandomAccessibleInterval} must have at least D components.
  * <p>
- * The deformation field should be interpreted as a d-dimensional
- * vector field.  A source point is displaced by adding the vector
- * at that point the the source point's position.
+ * The deformation field should be interpreted as a d-dimensional vector field.
+ * A source point is displaced by adding the vector at that point the the source
+ * point's position.
  *
  * @author John Bogovic &lt;bogovicj@janelia.hhmi.org&gt;
  *
  */
-public class DeformationFieldTransform<T extends RealType<T>> implements RealTransform
+public class DeformationFieldTransform< T extends RealType< T > > implements RealTransform
+//implements DifferentiableRealTransform
 {
 
 	private final RealRandomAccessible< T > defFieldReal;
@@ -89,6 +90,11 @@ public class DeformationFieldTransform<T extends RealType<T>> implements RealTra
 	public int numTargetDimensions()
 	{
 		return numDim;
+	}
+
+	public RealRandomAccess< T > getDefFieldAcess()
+	{
+		return defFieldAccess;
 	}
 
 	@Override
@@ -128,6 +134,6 @@ public class DeformationFieldTransform<T extends RealType<T>> implements RealTra
 	@Override
 	public RealTransform copy()
 	{
-		return new DeformationFieldTransform< >( this.defFieldReal );
+		return new DeformationFieldTransform<>( this.defFieldReal );
 	}
 }

--- a/src/main/java/net/imglib2/realtransform/InvertibleDeformationFieldTransform.java
+++ b/src/main/java/net/imglib2/realtransform/InvertibleDeformationFieldTransform.java
@@ -1,0 +1,14 @@
+package net.imglib2.realtransform;
+
+import net.imglib2.realtransform.inverse.WrappedIterativeInvertibleRealTransform;
+import net.imglib2.type.numeric.RealType;
+
+public class InvertibleDeformationFieldTransform< T extends RealType< T > > extends WrappedIterativeInvertibleRealTransform< DeformationFieldTransform< T > >
+{
+
+	public InvertibleDeformationFieldTransform( final DeformationFieldTransform< T > def )
+	{
+		super( def );
+	}
+
+}

--- a/src/main/java/net/imglib2/realtransform/ThinplateSplineTransform.java
+++ b/src/main/java/net/imglib2/realtransform/ThinplateSplineTransform.java
@@ -34,10 +34,16 @@
 
 package net.imglib2.realtransform;
 
+import org.ejml.data.DenseMatrix64F;
+import org.ejml.ops.CommonOps;
+import org.ejml.ops.NormOps;
+
 import jitk.spline.ThinPlateR2LogRSplineKernelTransform;
 import net.imglib2.RealLocalizable;
 import net.imglib2.RealPoint;
 import net.imglib2.RealPositionable;
+import net.imglib2.realtransform.inverse.AbstractDifferentiableRealTransform;
+import net.imglib2.realtransform.inverse.DifferentiableRealTransform;
 
 /**
  * An <em>n</em>-dimensional thin plate spline transform backed by John
@@ -45,8 +51,9 @@ import net.imglib2.RealPositionable;
  * library.
  *
  * @author Stephan Saalfeld
+ * @author John Bogovic
  */
-public class ThinplateSplineTransform implements RealTransform
+public class ThinplateSplineTransform extends AbstractDifferentiableRealTransform implements RealTransform
 {
 	final private ThinPlateR2LogRSplineKernelTransform tps;
 
@@ -55,6 +62,33 @@ public class ThinplateSplineTransform implements RealTransform
 	final private double[] b;
 
 	final private RealPoint rpa;
+
+	double[] estimateXfm;
+
+	/*
+	 * The jacobian matrix
+	 */
+	private AffineTransform jacobian;
+
+	/*
+	 * derivative in direction of dir (the descent direction )
+	 */
+	private DenseMatrix64F directionalDeriv;
+
+	/*
+	 * The descent direction
+	 */
+	private DenseMatrix64F dir;
+
+	/*
+	 * computes dir^T directionalDeriv (where dir^T is often -directionalDeriv)
+	 */
+	private DenseMatrix64F descentDirectionMag;
+
+	/*
+	 * error vector ( errorV = target - estimateXfm )
+	 */
+	private DenseMatrix64F errorV;
 
 	final static private ThinPlateR2LogRSplineKernelTransform init( final double[][] p, final double[][] q )
 	{
@@ -71,6 +105,7 @@ public class ThinplateSplineTransform implements RealTransform
 		a = new double[ tps.getNumDims() ];
 		b = new double[ a.length ];
 		rpa = RealPoint.wrap( a );
+		estimateXfm = new double[ tps.getNumDims() ];
 	}
 
 	public ThinplateSplineTransform( final double[][] p, final double[][] q )
@@ -111,4 +146,33 @@ public class ThinplateSplineTransform implements RealTransform
 	{
 		return tps.getNumDims();
 	}
+
+	private void initializeInverse()
+	{
+		int ndims = tps.getNumDims();
+		dir = new DenseMatrix64F( ndims, 1 );
+		errorV = new DenseMatrix64F( ndims, 1 );
+		directionalDeriv = new DenseMatrix64F( ndims, 1 );
+		descentDirectionMag = new DenseMatrix64F( 1, 1 );
+	}
+
+	public AffineTransform jacobian( final double[] x )
+	{
+		double[][] jac = tps.jacobian( x );
+		double[] jflat = new double[ x.length * ( x.length + 1 ) ];
+
+		int k = 0;
+		for( int i = 0; i< x.length; i++ )
+			for( int j = 0; j< (x.length +1); j++ )
+				if( j < x.length )
+					jflat[k++] = jac[i][j];
+				else
+					k++;
+
+		jacobian = new AffineTransform( x.length );
+		jacobian.set( jflat );
+
+		return jacobian;
+	}
+
 }

--- a/src/main/java/net/imglib2/realtransform/inverse/AbstractDifferentiableRealTransform.java
+++ b/src/main/java/net/imglib2/realtransform/inverse/AbstractDifferentiableRealTransform.java
@@ -1,0 +1,81 @@
+package net.imglib2.realtransform.inverse;
+
+import net.imglib2.realtransform.AffineTransform;
+
+public abstract class AbstractDifferentiableRealTransform implements DifferentiableRealTransform
+{
+	/**
+	 * Returns the jacobian matrix of this transform at the point x.
+	 * 
+	 * @param x
+	 *            the point
+	 * @return the jacobian
+	 */
+	public abstract AffineTransform jacobian( double[] x );
+
+	/**
+	 * Writes the direction <em>displacement</em> in which to move the input
+	 * source point <em>x</em> in order that F( x + d ) is closer to the
+	 * destination point <em>y</em> than F( x ).
+	 * <p>
+	 * The output is a normalized vector.
+	 * 
+	 * @param displacement
+	 *            the displacement to write into
+	 * @param x
+	 *            the source point
+	 * @param y
+	 *            the destination point
+	 * @return the direction
+	 */
+	public void directionToward( final double[] displacement, final double[] x, final double[] y )
+	{
+		directionToward( jacobian( x ), displacement, x, y );
+	}
+
+	public static void directionToward( final AffineTransform jacobian, final double[] displacement, final double[] x, final double[] y )
+	{
+		double[] err = new double[ x.length ];
+		for ( int i = 0; i < x.length; i++ )
+			err[ i ] = y[ i ] - x[ i ];
+
+		double[] dir = new double[ x.length ];
+		//jacobian.inverse().apply( err, dir );
+		matrixTranspose( jacobian ).apply( err, dir );
+
+		double norm = 0.0;
+		for ( int i = 0; i < dir.length; i++ )
+			norm += ( dir[ i ] * dir[ i ] );
+
+		norm = Math.sqrt( norm );
+
+		for ( int i = 0; i < dir.length; i++ )
+			dir[ i ] /= norm;
+
+		System.arraycopy( dir, 0, displacement, 0, dir.length );
+
+		/* compute the directional derivative
+		  double[] directionalDerivative = new double[ dir.length ];
+		*/
+
+		//jacobian.apply( dir, displacement );
+
+//		double descentDirectionMag = 0.0;
+//		for ( int i = 0; i < displacement.length; i++ )
+//			descentDirectionMag += ( displacement[ i ] * directionalDerivative[ i ] );
+	}
+
+	public static AffineTransform matrixTranspose( final AffineTransform a )
+	{
+		int nd = a.numDimensions();
+		final AffineTransform aT = new AffineTransform( nd );
+		double[][] mtx = new double[ nd ][ nd + 1 ];
+		for ( int i = 0; i < nd; i++ )
+			for ( int j = 0; j < nd; j++ )
+				mtx[ j ][ i ] = a.get( i, j );
+
+		aT.set( mtx );
+		return aT;
+	}
+
+}

--- a/src/main/java/net/imglib2/realtransform/inverse/BacktrackingLineSearch.java
+++ b/src/main/java/net/imglib2/realtransform/inverse/BacktrackingLineSearch.java
@@ -1,0 +1,347 @@
+package net.imglib2.realtransform.inverse;
+
+import java.util.Arrays;
+
+import org.apache.log4j.LogManager;
+import org.apache.log4j.Logger;
+
+import net.imglib2.realtransform.RealTransform;
+
+/**
+ * A generic backtracking line search to iteratively estimate the inverse of a {@link RealTransform}.
+ * This should never be used when a closed-form inverse is available.
+ * 
+ * @author John Bogovic
+ *
+ */
+public class BacktrackingLineSearch
+{
+	double[] target;	// target point
+	double[] x;			
+	double[] y;
+	
+	double fx;	
+	double[] x_ap;
+	double[] y_ap;
+	double[] dir;
+	
+	double currentSquaredError;
+	
+	private final int nd;
+	private DifferentiableRealTransform fwdXfm;
+	
+	// optimization parameters
+	private int maxIters = 1000;	// maximum iterations
+	private double eps = 0.1;		// maximum error
+	private double epsSquared = eps*eps;
+
+	// line search parameters
+	private double c = 0.5;
+	private double beta = 0.5;
+	private double initStepSize = 10;
+	private int lineSearchMaxTries = 16;		
+	
+	protected static Logger logger = LogManager.getLogger( 
+			BacktrackingLineSearch.class.getName() );
+
+	public BacktrackingLineSearch( final int nd )
+	{
+		this.nd = nd;
+		y = new double[ nd ];
+		x_ap = new double[ nd ];
+		y_ap = new double[ nd ];
+	}
+
+	public BacktrackingLineSearch( final DifferentiableRealTransform fwdXfm )
+	{
+		this.fwdXfm = fwdXfm;
+		this.nd = fwdXfm.numSourceDimensions();
+		y = new double[ nd ];
+		x_ap = new double[ nd ];
+		y_ap = new double[ nd ];
+	}
+
+	public void setForwardTransform( final DifferentiableRealTransform fwdXfm )
+	{
+		assert( fwdXfm.numSourceDimensions() == nd );
+		this.fwdXfm = fwdXfm;
+	}
+	
+	public void setC( final double c )
+	{
+		this.c = c;
+	}
+
+	public void setBeta( final double beta )
+	{
+		this.beta = beta;
+	}
+
+	public void setInitStep( final double initStepSize )
+	{
+		this.initStepSize = initStepSize;
+	}
+
+	public void setMaxIterations( final int maxIters )
+	{
+		this.maxIters = maxIters;
+	}
+
+	public void setMaxLineSearchTries( final int lineSearchMaxTries )
+	{
+		this.lineSearchMaxTries = lineSearchMaxTries;
+	}
+
+	public void setEpsilon( final double eps )
+	{
+		this.eps = eps;
+		epsSquared = eps*eps;
+	}
+
+	public void setEstimate( final double[] est )
+	{
+		this.x = est;
+		fwdXfm.apply( x, y );
+		fx = squaredError( y );
+	}
+
+	public void setTarget( final double[] tgt )
+	{
+		this.target = tgt;
+	}
+
+	public void setDirection( final double[] dir )
+	{
+		this.dir = dir;
+//		logger.trace( "    dir     : " + Arrays.toString( dir ));
+
+		double mag = dirMag();
+		for ( int i = 0; i < nd; i++ )
+			dir[ i ] = dir[ i ] / mag;
+
+//		logger.trace( "    dir norm: " + Arrays.toString( dir ));
+	}
+	
+	/**
+	 * Compute the squared error between this estimate and the target.
+	 * 
+	 * @param estimate the current estimate
+	 * @return the squared error
+	 */
+	public double squaredError( double[] estimate )
+	{
+		double squaredError = 0;
+		for ( int d = 0; d < nd; d++ )
+		{
+			squaredError += ( estimate[ d ] - target[ d ]) * ( estimate[ d ] - target[ d ]);
+		}
+		return squaredError;
+	}
+
+	/**
+	 * Compute the squared error between the destination of the input source point
+	 * and the target.
+	 * 
+	 * @param source the current source
+	 * @return the squared error
+	 */
+	public double squaredErrorAt( double[] source )
+	{
+		double[] srcXfm = new double[ nd ];
+		fwdXfm.apply( source, srcXfm );
+		double squaredError = 0;
+		for ( int d = 0; d < nd; d++ )
+		{
+			squaredError += ( srcXfm[ d ] - target[ d ]) * ( srcXfm[ d ] - target[ d ]);
+		}
+		return squaredError;
+	}
+
+	public double dirMag()
+	{
+		double mag = 0;
+		for ( int i = 0; i < nd; i++ )
+			mag += dir[ i ] * dir[ i ];
+		
+		return Math.sqrt( mag );
+	}
+	
+	/**
+	 * Perform backtracking line search.
+	 * 
+	 * @param c the armijoCondition parameter
+	 * @param beta the fraction to multiply the step size at each iteration ( < 1 )
+	 * @param maxtries max number of tries
+	 * @param t0 initial step size
+	 * @return the step size
+	 */
+	public double backtrackingLineSearch( double c, double beta, int maxtries, double t0 )
+	{
+		double t = t0; // step size
+
+		int k = 0;
+		// boolean success = false;
+		while ( k < maxtries )
+		{
+			if ( armijoCondition( c, t ) )
+			{
+				// success = true;
+				break;
+			}
+			else
+				t *= beta;
+
+			k++;
+		}
+
+		return t;
+	}
+	
+	private double sumSquaredErrorsDeriv( double[] y, double[] x )
+	{
+		double errDeriv = 0.0;
+		for ( int i = 0; i < nd; i++ )
+			errDeriv += ( y[ i ] - x[ i ] ) * ( y[ i ] - x[ i ] );
+
+		return 2 * errDeriv;
+	}
+	
+	private boolean armijoCondition( double c, double t )
+	{
+		for ( int i = 0; i < x.length; i++ )
+			x_ap[ i ] = x[ i ] + t * dir[ i ];
+		
+		fwdXfm.apply( x_ap, y_ap );
+		double fx_ap = squaredError( y_ap );
+		
+		//double m = sumSquaredErrorsDeriv( this.target, y_ap ); // * descentDirectionMag.get( 0 );
+		double m = 1;
+
+//		logger.trace( "   x   : " + Arrays.toString( x ));
+//		logger.trace( "   x_ap: " + Arrays.toString( x_ap ));
+//		logger.trace( "   y   : " + Arrays.toString( y ));
+//		logger.trace( "   y_ap: " + Arrays.toString( y_ap ));
+//		logger.trace( "   fx      : " + fx );
+//		logger.trace( "   fx_ap   : " + fx_ap );
+//		logger.trace( "   fx + ctm: " + ( fx - (c*t*m)) ) ;
+
+//		System.out.println( "   x   : " + Arrays.toString( x ));
+//		System.out.println( "   x_ap: " + Arrays.toString( x_ap ));
+//		System.out.println( "   y   : " + Arrays.toString( y ));
+//		System.out.println( "   y_ap: " + Arrays.toString( y_ap ));
+//		System.out.println( "   fx      : " + fx );
+//		System.out.println( "   fx_ap   : " + fx_ap );
+//		System.out.println( "   fx + ctm: " + ( fx - (c*t*m)) ) ;
+
+		if ( fx_ap < fx - c * t * m )
+		{
+			currentSquaredError = fx_ap;
+			return true;
+		}
+		else
+			return false;
+	}
+	
+	/**
+	 * Find the source point that, when pushed through the forward transform,
+	 * results in the given destination point.  Iteratively estimates the result
+	 * with backtracking line search.
+	 * <p>
+	 * Terminates either when a maximum iteration count has been reached, or the error
+	 * falls below a specified threshold.
+	 * 
+	 * @param source the source point that will be overwritten
+	 * @param destination the destination point
+	 * @return error of inverse
+	 */
+	public double iterativeInverse( final double[] source, final double[] destination )
+	{
+//		System.out.println( "start source: " + Arrays.toString( source ) );
+//		System.out.println( " " );
+
+		// keep track of target globally
+		this.target = destination;
+		
+		// initialize at destination
+//		System.arraycopy( destination, 0, source, 0, source.length );
+
+		double stepSize = initStepSize;		
+		
+		// temporary destination
+		double[] tmp = new double[ nd ];
+		
+		// temporary src
+		double[] tmpsrc = new double[ nd ];
+				
+		// the displacement
+		double[] displacement = new double[ nd ];
+		
+		double olderror = Double.MAX_VALUE;
+		double currentError = 0;
+
+		int i = 0;
+		while( i < maxIters )
+		{
+			stepSize = initStepSize;
+//			System.out.println( "i: " + i );
+
+			setEstimate( source );
+
+			fwdXfm.directionToward( displacement, source, destination );
+//			System.out.println( "displacement: " + Arrays.toString( displacement ));
+
+			setDirection( displacement );
+			stepSize = backtrackingLineSearch( c, beta, lineSearchMaxTries, stepSize );
+
+//			System.out.println( "stepSize: " + stepSize );
+
+			for ( int d = 0; d < nd; d++ )
+			{
+				tmpsrc[ d ] = source[ d ] + stepSize * displacement[ d ]; 
+			}
+//			System.out.println( "tmpsrc: " + Arrays.toString( tmpsrc ) );
+
+			fwdXfm.apply( tmpsrc, tmp );
+			currentError = squaredError( tmp );
+//			System.out.println( "tmpdst: " + Arrays.toString( tmp ) );
+
+//			System.out.println( "squared err: " + currentError );
+			if( currentError > olderror )
+			{
+//				System.out.println( "breaking early");
+				// make sure to return error (not squared)
+				return Math.sqrt( currentError );
+			}
+			else
+			{
+				System.arraycopy( tmpsrc, 0, source, 0, source.length );
+			}
+			olderror = currentError;
+
+//			System.out.println( "source: " + Arrays.toString( source ) );
+//			System.out.println( " " );
+
+			if( currentError < epsSquared )
+			{
+//				System.out.println( "breaking early");
+				break;
+			}
+			i++;
+		}
+
+		currentSquaredError = currentError;
+
+		// make sure to return error (not squared)		
+		return Math.sqrt( currentError );
+	}
+
+	public double getLastSquaredError()
+	{
+		return currentSquaredError;
+	}
+
+	public double getLastError()
+	{
+		return Math.sqrt( currentSquaredError );
+	}
+}

--- a/src/main/java/net/imglib2/realtransform/inverse/DifferentiableRealTransform.java
+++ b/src/main/java/net/imglib2/realtransform/inverse/DifferentiableRealTransform.java
@@ -1,0 +1,46 @@
+package net.imglib2.realtransform.inverse;
+
+import net.imglib2.realtransform.AffineTransform;
+import net.imglib2.realtransform.RealTransform;
+
+/**
+ * Transformation that can explicitly compute its derivative (jacobian).
+ * <p>
+ * {@link DifferentiableRealTransform}s can have their inverse iteratively
+ * estimated by gradient descent, see
+ * {@link InverseRealTransformGradientDescent}.
+ * 
+ * 
+ * @author John Bogovic &lt;bogovicj@janelia.hhmi.org&gt;
+ *
+ */
+public interface DifferentiableRealTransform extends RealTransform
+{
+
+	/**
+	 * Returns the jacobian matrix of this transform at the point x.
+	 * 
+	 * @param x
+	 *            the point
+	 * @return the jacobian
+	 */
+	public AffineTransform jacobian( double[] x );
+
+	/**
+	 * Writes the direction <em>displacement</em> in which to move the input
+	 * source point <em>x</em> in order that F( x + d ) is closer to the
+	 * destination point <em>y</em> than F( x ).
+	 * <p>
+	 * The output is a normalized vector.
+	 * 
+	 * @param displacement
+	 *            the displacement to write into
+	 * @param x
+	 *            the source point
+	 * @param y
+	 *            the destination point
+	 * @return the direction
+	 */
+	public void directionToward( final double[] displacement, final double[] x, final double[] y );
+
+}

--- a/src/main/java/net/imglib2/realtransform/inverse/InverseRealTransformGradientDescent.java
+++ b/src/main/java/net/imglib2/realtransform/inverse/InverseRealTransformGradientDescent.java
@@ -1,0 +1,499 @@
+package net.imglib2.realtransform.inverse;
+
+import net.imglib2.RealLocalizable;
+import net.imglib2.RealPositionable;
+import net.imglib2.realtransform.AffineTransform;
+import net.imglib2.realtransform.RealTransform;
+
+import java.util.Arrays;
+
+import org.apache.log4j.LogManager;
+import org.apache.log4j.Logger;
+
+public class InverseRealTransformGradientDescent implements RealTransform
+{
+	int ndims;
+
+	AffineTransform jacobian;
+
+	double[] directionalDeriv; // derivative in direction of dir (the
+								// descent direction )
+
+	double descentDirectionMag; // computes dir^T directionalDeriv
+								// (where dir^T is often
+								// -directionalDeriv)
+
+	double[] dir; // descent direction
+
+	double[] errorV; // error vector ( errorV = target - estimateXfm )
+
+	double[] estimate; // current estimate
+
+	double[] estimateXfm; // current estimateXfm
+
+	double[] target;
+
+	boolean fixZ = false;
+
+	double error = 9999.0;
+
+	double stepSz = 1.0;
+
+	double beta = 0.7;
+
+	double tolerance = 0.5;
+
+	double c = 0.0001;
+
+	int maxIters = 100;
+
+	double jacobianEstimateStep = 1.0;
+
+	double jacobianRegularizationEps = 0.1;
+
+	int stepSizeMaxTries = 10;
+
+	double maxStepSize = Double.MAX_VALUE;
+
+	double minStepSize = 1e-9;
+
+	private DifferentiableRealTransform xfm;
+
+	private double[] guess; // initialization for iterative inverse
+
+	//private double[] src; // source point (unmodified)
+
+	//private double[] tgt; // target point (unmodified)
+
+	protected static Logger logger = LogManager.getLogger( InverseRealTransformGradientDescent.class.getName() );
+
+	public InverseRealTransformGradientDescent( int ndims, DifferentiableRealTransform xfm )
+	{
+		this.ndims = ndims;
+		this.xfm = xfm;
+		dir = new double[ ndims ];
+		errorV = new double[ ndims ];
+		directionalDeriv = new double[ ndims ];
+		descentDirectionMag = 0.0;
+		jacobian = new AffineTransform( ndims );
+
+//		src = new double[ ndims ];
+//		tgt = new double[ ndims ];
+
+		target = new double[ ndims ];
+		estimate = new double[ ndims ];
+		estimateXfm = new double[ ndims ];
+	}
+
+	public void setBeta( double beta )
+	{
+		this.beta = beta;
+	}
+
+	public void setC( double c )
+	{
+		this.c = c;
+	}
+
+	public void setTolerance( final double tol )
+	{
+		this.tolerance = tol;
+	}
+
+	public void setMaxIters( final int maxIters )
+	{
+		this.maxIters = maxIters;
+	}
+
+	public void setFixZ( boolean fixZ )
+	{
+		this.fixZ = fixZ;
+	}
+
+	public void setStepSize( double stepSize )
+	{
+		stepSz = stepSize;
+	}
+
+	public void setMinStep( double minStep )
+	{
+		this.minStepSize = minStep;
+	}
+
+	public void setMaxStep( double maxStep )
+	{
+		this.maxStepSize = maxStep;
+	}
+
+	public void setJacobianEstimateStep( final double jacStep )
+	{
+		this.jacobianEstimateStep = jacStep;
+	}
+
+	public void setJacobianRegularizationEps( final double e )
+	{
+		this.jacobianRegularizationEps = e;
+	}
+
+	public void setStepSizeMaxTries( int stepSizeMaxTries )
+	{
+		this.stepSizeMaxTries = stepSizeMaxTries;
+	}
+
+	public void setTarget( double[] tgt )
+	{
+		System.arraycopy( tgt, 0, target, 0, ndims );
+	}
+
+	public double[] getErrorVector()
+	{
+		return errorV;
+	}
+
+	public double[] getDirection()
+	{
+		return dir;
+	}
+
+	public void setEstimate( double[] est )
+	{
+		System.arraycopy( est, 0, estimate, 0, ndims );
+	}
+
+	public void setEstimateXfm( double[] est )
+	{
+		System.arraycopy( est, 0, estimateXfm, 0, ndims );
+	}
+
+	public double[] getEstimate()
+	{
+		return estimate;
+	}
+
+	public double getError()
+	{
+		return error;
+	}
+
+	public int numSourceDimensions()
+	{
+		return ndims;
+	}
+
+	@Override
+	public int numTargetDimensions()
+	{
+		return ndims;
+	}
+
+	@Override
+	public RealTransform copy()
+	{
+		return new InverseRealTransformGradientDescent( ndims, xfm );
+	}
+
+	public void setGuess( final double[] guess )
+	{
+		this.guess = guess;
+	}
+
+	public void apply( final double[] s, final double[] t )
+	{
+		// tgt is the error estimate
+		double err = inverseTol( s, s, tolerance, maxIters );
+
+		// copy estimate into t
+		System.arraycopy( estimate, 0, t, 0, t.length );
+
+//		if( err > tolerance )
+//			System.out.println( "err: " + err + " >  EPS ( " + tolerance + " )" );
+	}
+
+	@Deprecated
+	public void apply( final float[] src, final float[] tgt )
+	{
+		double[] srcd = new double[ src.length ];
+		double[] tgtd = new double[ tgt.length ];
+		for ( int i = 0; i < src.length; i++ )
+			srcd[ i ] = src[ i ];
+
+		apply( srcd, tgtd );
+
+		for ( int i = 0; i < tgt.length; i++ )
+			tgt[ i ] = ( float ) tgtd[ i ];
+	}
+
+	public void apply( final RealLocalizable src, final RealPositionable tgt )
+	{
+		double[] srcd = new double[ src.numDimensions() ];
+		double[] tgtd = new double[ tgt.numDimensions() ];
+		src.localize( srcd );
+		apply( src, tgt );
+		tgt.setPosition( tgtd );
+	}
+
+	public double inverseTol( final double[] target, final double[] guess, final double tolerance, final int maxIters )
+	{
+		// TODO - have a flag in the apply method to also return the derivative
+		// if requested
+		// to prevent duplicated effort
+
+		// TODO should this be
+		this.target = target;
+
+		/*
+		 * initialize the error to a big enough number This shouldn't matter
+		 * since the error is updated below after the estimate updated.
+		 */
+		error = 999 * tolerance;
+
+		setEstimate( guess );
+
+		//xfm.apply( guess, guessXfm );
+		xfm.apply( estimate, estimateXfm );
+
+		//setTarget( target );
+		//setEstimate( guess );
+		updateError();
+
+//		System.out.println( "target : " + Arrays.toString( target ));
+//		System.out.println( "estimate : " + Arrays.toString( estimate ));
+//		System.out.println( "estXfm   : " + Arrays.toString( estimateXfm ));
+
+		double t = 1.0;
+		int k = 0;
+		while ( error >= tolerance && k < maxIters )
+		{
+
+//			System.out.println( "k: " + k );
+			/*
+			 * xfm.jacobian( estimate );
+			 * 
+			 * if( jacobianRegularizationEps > 0 ) regularizeJacobian();
+			 */
+
+			// TODO the above lines may be important
+			// if we want to regularize the jacobian
+			// xfm.directionToward( errorV, estimate, dir );
+			xfm.directionToward( dir, estimateXfm, target );
+
+			/* the two below lines should give identical results */
+//			t = backtrackingLineSearch( c, beta, stepSizeMaxTries, t0 );
+			t = backtrackingLineSearch( error );
+			
+
+			if ( t == 0.0 )
+				break;
+
+			updateEstimate( t ); // go in negative direction to reduce cost
+			xfm.apply( estimate, estimateXfm );
+			updateError();
+
+			error = getError();
+
+//			System.out.println( "t: " + t );
+//			System.out.println( "dir      : " + Arrays.toString( dir ));
+//			System.out.println( "errV      : " + Arrays.toString( errorV ));
+//			System.out.println( "estimate : " + Arrays.toString( estimate ));
+//			System.out.println( "estXfm   : " + Arrays.toString( estimateXfm ));
+//			System.out.println( "error      : " + error );
+//			System.out.println( " " );
+
+			k++;
+		}
+
+		return error;
+	}
+
+	public void regularizeJacobian()
+	{
+		// Changes jacobian (J) to be:
+		// ( 1-eps ) * J + ( eps ) * I
+		//
+		// note jacRegMatrix = eps * I
+		for ( int i = 0; i < ndims; i++ )
+		{
+			jacobian.set( jacobianRegularizationEps + jacobian.get( i, i ), i, i );
+		}
+	}
+
+	/**
+	 * Uses Backtracking Line search to determine a step size.
+	 * 
+	 * @param c
+	 *            the armijoCondition parameter
+	 * @param beta
+	 *            the fraction to multiply the step size at each iteration (
+	 *            less than 1 )
+	 * @param maxtries
+	 *            max number of tries
+	 * @param t0
+	 *            initial step size
+	 * @return the step size
+	 */
+	public double backtrackingLineSearch( double t0 )
+	{
+		double t = t0; // step size
+
+		int k = 0;
+		// boolean success = false;
+		while ( k < stepSizeMaxTries )
+		{
+			if ( armijoCondition( c, t ) )
+			{
+				// success = true;
+				break;
+			}
+			else
+				t *= beta;
+
+			k++;
+		}
+
+		if ( t < minStepSize )
+			return minStepSize;
+
+		if ( t > maxStepSize )
+			return maxStepSize;
+
+		return t;
+	}
+
+	/**
+	 * Uses Backtracking Line search to determine a step size.
+	 * 
+	 * @param c
+	 *            the armijoCondition parameter
+	 * @param beta
+	 *            the fraction to multiply the step size at each iteration (
+	 *            less than 1 )
+	 * @param maxtries
+	 *            max number of tries
+	 * @param t0
+	 *            initial step size
+	 * @return the step size
+	 */
+	public double backtrackingLineSearch( double c, double beta, int maxtries, double t0 )
+	{
+		double t = t0; // step size
+
+		int k = 0;
+		// boolean success = false;
+		while ( k < maxtries )
+		{
+			if ( armijoCondition( c, t ) )
+			{
+				// success = true;
+				break;
+			}
+			else
+				t *= beta;
+
+			k++;
+		}
+
+		return t;
+	}
+
+	/**
+	 * Returns true if the armijo condition is satisfied.
+	 * 
+	 * @param c
+	 *            the c parameter
+	 * @param t
+	 *            the step size
+	 * @return true if the step size satisfies the condition
+	 */
+	public boolean armijoCondition( double c, double t )
+	{
+		double[] d = dir;
+		double[] x = estimate; // give a convenient name
+
+		double[] x_ap = new double[ ndims ];
+		for ( int i = 0; i < ndims; i++ )
+			x_ap[ i ] = x[ i ] + t * d[ i ];
+
+		// don't have to do this in here - this should be reused
+		// double[] phix = xfm.apply( x );
+		// TODO make sure estimateXfm is updated at the correct time
+		double[] phix = estimateXfm;
+		double[] phix_ap = new double[ this.ndims ];
+		xfm.apply( x_ap, phix_ap );
+
+		double fx = squaredError( phix );
+		double fx_ap = squaredError( phix_ap );
+
+		double m = sumSquaredErrorsDeriv( this.target, phix ) * descentDirectionMag;
+
+		if ( fx_ap < fx + c * t * m )
+			return true;
+		else
+			return false;
+	}
+
+	public double squaredError( double[] x )
+	{
+		double error = 0;
+		for ( int i = 0; i < ndims; i++ )
+			error += ( x[ i ] - this.target[ i ] ) * ( x[ i ] - this.target[ i ] );
+
+		return error;
+	}
+
+	public void updateEstimate( double stepSize )
+	{
+		for ( int i = 0; i < ndims; i++ )
+			estimate[ i ] += stepSize * dir[ i ];
+	}
+
+	public void updateError()
+	{
+		if ( estimate == null || target == null )
+		{
+			System.err.println( "WARNING: Call to updateError with null target or estimate" );
+			return;
+		}
+
+		// ( errorV = target - estimateXfm )
+		for ( int i = 0; i < ndims; i++ )
+			errorV[ i ] = target[ i ] - estimateXfm[ i ];
+
+		// set scalar error to magnitude of error gradient
+		error = 0.0;
+		for ( int i = 0; i < ndims; i++ )
+		{
+			error += errorV[ i ] * errorV[ i ];
+		}
+
+		error = Math.sqrt( error );
+	}
+
+	/**
+	 * This function returns \nabla f ^T \nabla f where f = || y - x ||^2 and
+	 * the gradient is taken with respect to x
+	 * 
+	 * @param y
+	 * @param x
+	 * @return
+	 */
+	private double sumSquaredErrorsDeriv( double[] y, double[] x )
+	{
+		double errDeriv = 0.0;
+		for ( int i = 0; i < ndims; i++ )
+			errDeriv += ( y[ i ] - x[ i ] ) * ( y[ i ] - x[ i ] );
+
+		return 2 * errDeriv;
+	}
+
+	public static double sumSquaredErrors( double[] y, double[] x )
+	{
+		int ndims = y.length;
+
+		double err = 0.0;
+		for ( int i = 0; i < ndims; i++ )
+			err += ( y[ i ] - x[ i ] ) * ( y[ i ] - x[ i ] );
+
+		return err;
+	}
+
+}

--- a/src/main/java/net/imglib2/realtransform/inverse/InvertibleTransformByGradientDescent.java
+++ b/src/main/java/net/imglib2/realtransform/inverse/InvertibleTransformByGradientDescent.java
@@ -1,0 +1,114 @@
+package net.imglib2.realtransform.inverse;
+
+import net.imglib2.RealLocalizable;
+import net.imglib2.RealPositionable;
+import net.imglib2.realtransform.InvertibleRealTransform;
+
+/**
+ * Use gradient descent to iteratively estimate the inverse of a differentiable
+ * forward transformation.
+ * 
+ * @author John Bogovic
+ *
+ */
+public class InvertibleTransformByGradientDescent implements InvertibleRealTransform
+{
+	final boolean isInverse;
+
+	final DifferentiableRealTransform forwardTransform;
+
+	final BacktrackingLineSearch inverseTransform;
+
+	public InvertibleTransformByGradientDescent( final DifferentiableRealTransform forwardTransform )
+	{
+		this( forwardTransform, false );
+	}
+
+	public InvertibleTransformByGradientDescent( final DifferentiableRealTransform forwardTransform, final boolean isInverse )
+	{
+		this( forwardTransform, new BacktrackingLineSearch( forwardTransform ), isInverse );
+	}
+
+	public InvertibleTransformByGradientDescent( final DifferentiableRealTransform forwardTransform, final BacktrackingLineSearch inverseTransform, final boolean isInverse )
+	{
+		this.forwardTransform = forwardTransform;
+		this.inverseTransform = inverseTransform;
+
+		this.isInverse = isInverse;
+	}
+
+	@Override
+	public void apply( double[] p, double[] q )
+	{
+		if ( isInverse )
+			inverseTransform.iterativeInverse( p, q );
+		else
+			forwardTransform.apply( p, q );
+	}
+
+	@Override
+	public void apply( RealLocalizable p, RealPositionable q )
+	{
+		if ( isInverse )
+		{
+			double[] pd = new double[ p.numDimensions() ];
+			double[] qd = new double[ p.numDimensions() ];
+
+			p.localize( pd );
+			inverseTransform.iterativeInverse( pd, qd );
+			q.setPosition( qd );
+		}
+		else
+			forwardTransform.apply( p, q );
+	}
+
+	@Override
+	public void applyInverse( double[] p, double[] q )
+	{
+		if ( isInverse )
+			forwardTransform.apply( p, q );
+		else
+			inverseTransform.iterativeInverse( p, q );
+	}
+
+	@Override
+	public void applyInverse( RealPositionable p, RealLocalizable q )
+	{
+		if ( isInverse )
+			forwardTransform.apply( q, p );
+		else
+		{
+			double[] pd = new double[ p.numDimensions() ];
+			double[] qd = new double[ p.numDimensions() ];
+
+			q.localize( qd );
+			inverseTransform.iterativeInverse( qd, pd );
+			p.setPosition( pd );
+		}
+	}
+
+	@Override
+	public InvertibleTransformByGradientDescent copy()
+	{
+		return new InvertibleTransformByGradientDescent( forwardTransform, isInverse );
+	}
+
+	@Override
+	public InvertibleTransformByGradientDescent inverse()
+	{
+		return new InvertibleTransformByGradientDescent( forwardTransform, !isInverse );
+	}
+
+	@Override
+	public int numSourceDimensions()
+	{
+		return forwardTransform.numSourceDimensions();
+	}
+
+	@Override
+	public int numTargetDimensions()
+	{
+		return forwardTransform.numTargetDimensions();
+	}
+
+}

--- a/src/main/java/net/imglib2/realtransform/inverse/RealTransformFiniteDerivatives.java
+++ b/src/main/java/net/imglib2/realtransform/inverse/RealTransformFiniteDerivatives.java
@@ -1,0 +1,101 @@
+package net.imglib2.realtransform.inverse;
+
+import net.imglib2.RealLocalizable;
+import net.imglib2.RealPositionable;
+import net.imglib2.realtransform.AffineTransform;
+import net.imglib2.realtransform.RealTransform;
+
+/**
+ * Use finite differences to estimate the jacobian of an arbitrary
+ * RealTransform.
+ * 
+ * @author John Bogovic
+ *
+ */
+public class RealTransformFiniteDerivatives extends AbstractDifferentiableRealTransform
+{
+	protected final RealTransform transform;
+
+	protected final AffineTransform jacobian;
+
+	protected double step;
+
+	public RealTransformFiniteDerivatives( final RealTransform transform )
+	{
+		this.transform = transform;
+		int srcD = transform.numSourceDimensions();
+		int tgtD = transform.numTargetDimensions();
+		jacobian = new AffineTransform( srcD > tgtD ? srcD : tgtD );
+		step = 0.01;
+	}
+
+	public void setStep( double step )
+	{
+		this.step = step;
+	}
+
+	public int numSourceDimensions()
+	{
+		return transform.numSourceDimensions();
+	}
+
+	public int numTargetDimensions()
+	{
+		return transform.numTargetDimensions();
+	}
+
+	public void apply( double[] source, double[] target )
+	{
+		transform.apply( source, target );
+	}
+
+	public void apply( RealLocalizable source, RealPositionable target )
+	{
+		transform.apply( source, target );
+	}
+
+	public RealTransform copy()
+	{
+		return new RealTransformFiniteDerivatives( transform );
+	}
+
+	/**
+	 * Estimates the jacobian matrix at x of the wrapped RealTransform. Returns
+	 * an {@link AffineTransform} so that matrix operations are convenient.
+	 * 
+	 * @param x
+	 *            the point at which to estimate the jacobian
+	 * @return the jacobian
+	 */
+	public AffineTransform jacobian( double[] x )
+	{
+		int ndims = numSourceDimensions();
+		double[] p = new double[ ndims ];
+		double[] q = new double[ ndims ];
+		double[] qc = new double[ ndims ];
+
+		double[][] newjac = new double[ ndims ][ ndims+1 ];
+
+		transform.apply( x, qc );
+
+		for ( int i = 0; i < ndims; i++ )
+		{
+			for ( int j = 0; j < ndims; j++ )
+				if ( j == i )
+					p[ j ] = x[ j ] + step;
+				else
+					p[ j ] = x[ j ];
+
+			transform.apply( p, q );
+
+			for ( int j = 0; j < ndims; j++ )
+			{
+				newjac[ j ][ i ] = ( q[ j ] - qc[ j ] ) / step;
+			}
+		}
+		jacobian.set( newjac );
+
+		return jacobian;
+	}
+	
+}

--- a/src/main/java/net/imglib2/realtransform/inverse/RegularizedDifferentiableRealTransform.java
+++ b/src/main/java/net/imglib2/realtransform/inverse/RegularizedDifferentiableRealTransform.java
@@ -1,0 +1,72 @@
+package net.imglib2.realtransform.inverse;
+
+import net.imglib2.RealLocalizable;
+import net.imglib2.RealPositionable;
+import net.imglib2.realtransform.AffineTransform;
+import net.imglib2.realtransform.RealTransform;
+
+/**
+ * Wraps and regularizes a {@link DifferentiableRealTransform}.
+ * <p>
+ * Returns a convex combination of the identity matrix and the jacobian of the
+ * wrapped DifferentiableReal Transform. Specifically: 
+ * epsilon * I + ( 1 - * epsilon ) * J
+ * 
+ * @author John Bogovic &lt;bogovicj@janelia.hhmi.org&gt;
+ *
+ */
+public class RegularizedDifferentiableRealTransform extends AbstractDifferentiableRealTransform
+{
+
+	protected final DifferentiableRealTransform dxfm;
+
+	protected final double epsilon;
+
+	public RegularizedDifferentiableRealTransform( final DifferentiableRealTransform dxfm, final double epsilon )
+	{
+		this.dxfm = dxfm;
+		this.epsilon = epsilon;
+	}
+
+	/**
+	 * Returns the jacobian matrix of this transform at the point x.
+	 * 
+	 * @param x
+	 *            the point
+	 * @return the jacobian
+	 */
+	public AffineTransform jacobian( double[] x )
+	{
+		AffineTransform jac = dxfm.jacobian( x );
+		for ( int i = 0; i < jac.numSourceDimensions(); i++ )
+			jac.set( epsilon + ( 1 - epsilon ) * jac.get( i, i ), i, i );
+
+		return jac;
+	}
+
+	public int numSourceDimensions()
+	{
+		return dxfm.numSourceDimensions();
+	}
+
+	public int numTargetDimensions()
+	{
+		return dxfm.numTargetDimensions();
+	}
+
+	public void apply( double[] source, double[] target )
+	{
+		dxfm.apply( source, target );
+	}
+
+	public void apply( RealLocalizable source, RealPositionable target )
+	{
+		dxfm.apply( source, target );
+	}
+
+	public RealTransform copy()
+	{
+		return dxfm.copy();
+	}
+
+}

--- a/src/main/java/net/imglib2/realtransform/inverse/WrappedIterativeInvertibleRealTransform.java
+++ b/src/main/java/net/imglib2/realtransform/inverse/WrappedIterativeInvertibleRealTransform.java
@@ -1,0 +1,90 @@
+package net.imglib2.realtransform.inverse;
+
+import net.imglib2.RealLocalizable;
+import net.imglib2.RealPositionable;
+import net.imglib2.realtransform.InverseRealTransform;
+import net.imglib2.realtransform.InvertibleRealTransform;
+import net.imglib2.realtransform.RealTransform;
+
+public class WrappedIterativeInvertibleRealTransform< T extends RealTransform > implements InvertibleRealTransform
+{
+	protected final T forwardTransform;
+
+	protected final DifferentiableRealTransform differentiableTrasnform;
+
+	protected final InverseRealTransformGradientDescent inverseTransform;
+
+	public WrappedIterativeInvertibleRealTransform( final T xfm )
+	{
+		this.forwardTransform = xfm;
+
+		if( xfm instanceof DifferentiableRealTransform )
+		{
+			differentiableTrasnform = (DifferentiableRealTransform) xfm;
+		}
+		else
+		{
+			differentiableTrasnform = new RealTransformFiniteDerivatives( xfm );
+		}
+
+		inverseTransform = new InverseRealTransformGradientDescent( xfm.numSourceDimensions(), differentiableTrasnform );
+	}
+
+	public T getTransform()
+	{
+		return forwardTransform;
+	}
+
+	@Override
+	public int numSourceDimensions()
+	{
+		return forwardTransform.numSourceDimensions();
+	}
+
+	@Override
+	public int numTargetDimensions()
+	{
+		return forwardTransform.numTargetDimensions();
+	}
+
+	@Override
+	public void apply( double[] source, double[] target )
+	{
+		forwardTransform.apply( source, target );
+	}
+
+	@Override
+	public void apply( RealLocalizable source, RealPositionable target )
+	{
+		forwardTransform.apply( source, target );
+	}
+
+	@Override
+	public void applyInverse( double[] source, double[] target )
+	{
+		inverseTransform.apply( target, source );
+	}
+
+	@Override
+	public void applyInverse( RealPositionable source, RealLocalizable target )
+	{
+		inverseTransform.apply( target, source );
+	}
+
+	@Override
+	public InvertibleRealTransform inverse()
+	{
+		return new InverseRealTransform( this );
+	}
+
+	public InverseRealTransformGradientDescent getOptimzer()
+	{
+		return inverseTransform;
+	}
+
+	@Override
+	public InvertibleRealTransform copy()
+	{
+		return new WrappedIterativeInvertibleRealTransform< T >( forwardTransform );
+	}
+}

--- a/src/test/java/net/imglib2/realtransform/IterableInverseTests.java
+++ b/src/test/java/net/imglib2/realtransform/IterableInverseTests.java
@@ -1,0 +1,188 @@
+package net.imglib2.realtransform;
+
+import java.util.Arrays;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import net.imglib2.realtransform.inverse.DifferentiableRealTransform;
+import net.imglib2.realtransform.inverse.InverseRealTransformGradientDescent;
+import net.imglib2.realtransform.inverse.RealTransformFiniteDerivatives;
+import net.imglib2.realtransform.inverse.WrappedIterativeInvertibleRealTransform;
+
+public class IterableInverseTests
+{
+	public final double EPS = 0.0001;
+
+	@Test
+	public void testTpsInverseSimple()
+	{
+		/*
+		 * Simple TPS
+		 */
+		double[][] srcPts = new double[][]{
+				{ -1.0, 0.0, 1.0, 0.0 }, // x
+				{ 0.0, -1.0, 0.0, 1.0 } }; // y
+
+		double[][] tgtPts = new double[][]{
+				{ -2.0, 0.0, 2.0, 0.0 }, // x
+				{ 0.0, -2.0, 0.0, 2.0 } }; // y
+
+
+		ThinplateSplineTransform tps = new ThinplateSplineTransform( srcPts, tgtPts );
+		WrappedIterativeInvertibleRealTransform<ThinplateSplineTransform> tpsInv = new WrappedIterativeInvertibleRealTransform<>( tps );
+		
+		
+		double[] x = new double[]{ 0.5, 0.5 };
+		double[] y  = new double[ 2 ];
+		double[] yest = new double[ 2 ];
+		double[] yestinv = new double[ 2 ];
+		
+		tpsInv.getOptimzer().setTolerance( EPS / 2 );
+		
+		tps.apply( x, y );
+		tpsInv.applyInverse( yest, y );
+		tps.apply( yest, yestinv );
+		
+		Assert.assertArrayEquals("tps", x, yest, EPS );
+	}
+
+	@Test
+	public void testTpsInverse()
+	{
+		/*
+		 * Warp
+		 */
+		final double[][] src_simple = new double[][]
+		{
+				{ 0, 0, 0, 1, 1, 1, 2, 2, 2 }, // x
+				{ 0, 1, 2, 0, 1, 2, 0, 1, 2 }, // y
+		};
+		// target points
+		final double[][] tgt = new double[][]
+		{
+				{ -0.5, -0.5, -0.5, 1.5, 1.5, 1.5, 2.0, 2.0, 2.0 }, // x
+				{ -0.5, 1.5, 2.0, -0.5, 1.5, 2.0, -0.5, 1.5, 2.0 } // y
+		};
+
+		final ThinplateSplineTransform tps = new ThinplateSplineTransform( src_simple, tgt );
+		WrappedIterativeInvertibleRealTransform<ThinplateSplineTransform> tpsInv = new WrappedIterativeInvertibleRealTransform<>( tps );
+		tpsInv.getOptimzer().setTolerance( EPS / 2 );
+
+		/* **** PT 1 **** */
+		double[] x = new double[]{ 0.0f, 0.0f };
+		double[] y = new double[ 2 ];
+		double[] yi = new double[ 2 ];
+
+		tps.apply( x, y );
+		tpsInv.applyInverse( yi, y );
+		Assert.assertArrayEquals("tps warp inv 1", x, yi, EPS );
+
+
+		/* **** PT 2 **** */
+		x[ 0 ] = 0.5;
+		x[ 1 ] = 0.5;
+
+		tps.apply( x, y );
+		tpsInv.applyInverse( yi, y );
+		Assert.assertArrayEquals("tps warp inv 2", x, yi, EPS );
+
+
+		/* **** PT 3 **** */
+		x[ 0 ] = 1;
+		x[ 1 ] = 1;
+
+		tps.apply( x, y );
+		tpsInv.applyInverse( yi, y );
+		Assert.assertArrayEquals("tps warp inv 3", x, yi, EPS );
+
+
+		/* **** RANDOM PT SMALL **** */
+		x[ 0 ] = 0.6198672937136046;
+		x[ 1 ] = 0.3758563293461874;
+
+		tps.apply( x, y );
+		tpsInv.applyInverse( yi, y );
+		Assert.assertArrayEquals("tps warp inv 4", x, yi, EPS );
+
+
+		/* **** RANDOM PT NEG **** */
+		x[ 0 ] = -0.24032;
+		x[ 1 ] = -0.65288;
+
+		tps.apply( x, y );
+		tpsInv.applyInverse( yi, y );
+		Assert.assertArrayEquals("tps warp inv 5", x, yi, EPS );
+
+
+		/* **** RANDOM PT BIG **** */
+		x[ 0 ] = 4.983245;
+		x[ 1 ] = 3.124307;
+
+		tps.apply( x, y );
+		tpsInv.applyInverse( yi, y );
+		Assert.assertArrayEquals("tps warp inv 5", x, yi, EPS );
+	}
+
+	@Test
+	public void testAffineInverse()
+	{
+		double[] p = new double[]{ 3, 0.5, 30 };
+		double[] pxfm = new double[ 3 ];
+		double[] q = new double[ 3 ];
+
+		IterativeAffineInverse I3 = new IterativeAffineInverse( 3 );
+		
+		
+		I3.apply( p, pxfm );
+		I3.applyInverse( q, p );
+		Assert.assertArrayEquals( "identity matrix inverse", pxfm, q, EPS );
+
+		IterativeAffineInverse rot = new IterativeAffineInverse( 3 );
+
+		rot.set( 0.0, 1.0, 0.0, 0.1,
+				 -1.0, 0.0, 0.0, 8,
+				 0.0, 0.0, 1.0, 50 );
+		
+		
+		// a difficult case in which
+		// the optimizer must 
+		InverseRealTransformGradientDescent rotinverter = new InverseRealTransformGradientDescent( 
+				3, rot );
+		rotinverter.setTolerance( EPS / 20 );
+
+		rot.apply( p, pxfm );
+		rotinverter.apply( pxfm, q );
+
+		Assert.assertArrayEquals( "rotation matrix inverse", p, q, EPS );
+	}
+	
+	private class IterativeAffineInverse extends AffineTransform implements DifferentiableRealTransform
+	{
+		final AffineTransform jacobian;
+
+		// TODO move this class into tests
+		public IterativeAffineInverse( int n )
+		{
+			super( n );
+			jacobian = new AffineTransform( n );
+		}
+
+		@Override
+		public void directionToward( double[] displacement, double[] x, double[] y )
+		{
+			RealTransformFiniteDerivatives.directionToward( jacobian(x), displacement, x, y );
+		}
+
+		@Override
+		public AffineTransform jacobian( double[] x )
+		{
+			jacobian.set( this.getRowPackedCopy() );
+			for( int d = 0; d < n; d++ )
+				jacobian.set( 0.0, d, n );
+
+			return jacobian;
+		}
+
+	}
+}


### PR DESCRIPTION
This generalizes a method for finding inverse transformations for `RealTransform`s without close-form inverses.  I've used this successfully for `ThinPlateSplineTransform` and `DeformationFieldTransform`.

* Adds an interface `DifferentiableRealTransform` for `RealTransform`s that can compute their jacobian in a closed-form way (e.g. `ThinPlateSplineTransform`).

* Adds a wrapping class `RealTransformFiniteDerivatives` which turns any `RealTransform` into a `DifferentiableRealTransform` and computes the jacobian via finite-differences.

* Adds a convenience class `WrappedIterativeInvertibleRealTransform` that checks if the input `RealTransform` is a `DifferentiableRealTransform` or not and creates an appropriate `InvertibleRealTransform`

* Includes unit tests:
  * [Add inverse test for `DeformationFieldTransforms`](https://github.com/bogovicj/imglib2-realtransform/blob/ba284656de98841ee27eb44ed14ff09de2a2cf48/src/test/java/net/imglib2/realtransform/DeformationFieldTest.java#L182-L197)
  * [Adds `ThinplateSplineTransform` inverse tests](https://github.com/bogovicj/imglib2-realtransform/blob/ba284656de98841ee27eb44ed14ff09de2a2cf48/src/test/java/net/imglib2/realtransform/IterableInverseTests.java#L17-L125)
  * [For sanity, test iterative inverse from an `AffineTransform`](https://github.com/bogovicj/imglib2-realtransform/blob/ba284656de98841ee27eb44ed14ff09de2a2cf48/src/test/java/net/imglib2/realtransform/IterableInverseTests.java#L127-L187)