### PR TITLE
Speed up AffineTransform3D.estimateBounds

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -168,8 +168,6 @@ Jean-Yves Tinevez and Michael Zinsmaier.</license.copyrightOwners>
 
 		<!-- NB: Deploy releases to the SciJava Maven repository. -->
 		<releaseProfiles>deploy-to-scijava</releaseProfiles>
-
-		<imglib2.version>5.1.0</imglib2.version>
 	</properties>
 
 	<dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -190,6 +190,16 @@ Jean-Yves Tinevez and Michael Zinsmaier.</license.copyrightOwners>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
+			<groupId>org.openjdk.jmh</groupId>
+			<artifactId>jmh-core</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.openjdk.jmh</groupId>
+			<artifactId>jmh-generator-annprocess</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
 			<groupId>jitk</groupId>
 			<artifactId>jitk-tps</artifactId>
 		</dependency>

--- a/src/main/java/net/imglib2/realtransform/AffineTransform3D.java
+++ b/src/main/java/net/imglib2/realtransform/AffineTransform3D.java
@@ -41,7 +41,6 @@ import net.imglib2.RealPoint;
 import net.imglib2.RealPositionable;
 import net.imglib2.concatenate.Concatenable;
 import net.imglib2.concatenate.PreConcatenable;
-import net.imglib2.util.Util;
 
 /**
  * 3d-affine transformation.
@@ -991,7 +990,14 @@ public class AffineTransform3D implements AffineGet, AffineSet, Concatenable< Af
 		inverse.updateDs();
 	}
 
-	public FinalRealInterval estimateBoundsFast( final RealInterval interval )
+	/**
+	 * Calculate the boundary interval of an interval after it has been
+	 * transformed.
+	 *
+	 * @param interval the original bounds
+	 * @return the new bounds
+	 */
+	public FinalRealInterval estimateBounds( final RealInterval interval )
 	{
 		assert interval.numDimensions() >= 3: "Interval dimensions do not match.";
 
@@ -1065,96 +1071,6 @@ public class AffineTransform3D implements AffineGet, AffineSet, Concatenable< Af
 			rMin[ d ] = interval.realMin( d );
 			rMax[ d ] = interval.realMax( d );
 		}
-		return new FinalRealInterval( rMin, rMax );
-	}
-
-	/**
-	 * Calculate the boundary interval of an interval after it has been
-	 * transformed.
-	 *
-	 * @param interval the original bounds
-	 * @return the new bounds
-	 */
-	public FinalRealInterval estimateBounds( final RealInterval interval )
-	{
-		assert interval.numDimensions() >= 3: "Interval dimensions do not match.";
-
-		final double[] min = new double[ interval.numDimensions() ];
-		final double[] max = new double[ min.length ];
-		final double[] rMin = new double[ min.length ];
-		final double[] rMax = new double[ min.length ];
-		min[ 0 ] = interval.realMin( 0 );
-		min[ 1 ] = interval.realMin( 1 );
-		min[ 2 ] = interval.realMin( 2 );
-		max[ 0 ] = interval.realMax( 0 );
-		max[ 1 ] = interval.realMax( 1 );
-		max[ 2 ] = interval.realMax( 2 );
-		rMin[ 0 ] = rMin[ 1 ] = rMin[ 2 ] = Double.MAX_VALUE;
-		rMax[ 0 ] = rMax[ 1 ] = rMax[ 2 ] = -Double.MAX_VALUE;
-		for ( int d = 3; d < rMin.length; ++d )
-		{
-			rMin[ d ] = interval.realMin( d );
-			rMax[ d ] = interval.realMax( d );
-			min[ d ] = interval.realMin( d );
-			max[ d ] = interval.realMax( d );
-		}
-
-		final double[] f = new double[ 3 ];
-		final double[] g = new double[ 3 ];
-
-		apply( min, g );
-		Util.min( rMin, g );
-		Util.max( rMax, g );
-
-		f[ 0 ] = max[ 0 ];
-		f[ 1 ] = min[ 1 ];
-		f[ 2 ] = min[ 2 ];
-		apply( f, g );
-		Util.min( rMin, g );
-		Util.max( rMax, g );
-
-		f[ 0 ] = min[ 0 ];
-		f[ 1 ] = max[ 1 ];
-		f[ 2 ] = min[ 2 ];
-		apply( f, g );
-		Util.min( rMin, g );
-		Util.max( rMax, g );
-
-		f[ 0 ] = max[ 0 ];
-		f[ 1 ] = max[ 1 ];
-		f[ 2 ] = min[ 2 ];
-		apply( f, g );
-		Util.min( rMin, g );
-		Util.max( rMax, g );
-
-		f[ 0 ] = min[ 0 ];
-		f[ 1 ] = min[ 1 ];
-		f[ 2 ] = max[ 2 ];
-		apply( f, g );
-		Util.min( rMin, g );
-		Util.max( rMax, g );
-
-		f[ 0 ] = max[ 0 ];
-		f[ 1 ] = min[ 1 ];
-		f[ 2 ] = max[ 2 ];
-		apply( f, g );
-		Util.min( rMin, g );
-		Util.max( rMax, g );
-
-		f[ 0 ] = min[ 0 ];
-		f[ 1 ] = max[ 1 ];
-		f[ 2 ] = max[ 2 ];
-		apply( f, g );
-		Util.min( rMin, g );
-		Util.max( rMax, g );
-
-		f[ 0 ] = max[ 0 ];
-		f[ 1 ] = max[ 1 ];
-		f[ 2 ] = max[ 2 ];
-		apply( f, g );
-		Util.min( rMin, g );
-		Util.max( rMax, g );
-
 		return new FinalRealInterval( rMin, rMax );
 	}
 

--- a/src/main/java/net/imglib2/realtransform/AffineTransform3D.java
+++ b/src/main/java/net/imglib2/realtransform/AffineTransform3D.java
@@ -991,6 +991,83 @@ public class AffineTransform3D implements AffineGet, AffineSet, Concatenable< Af
 		inverse.updateDs();
 	}
 
+	public FinalRealInterval estimateBoundsFast( final RealInterval interval )
+	{
+		assert interval.numDimensions() >= 3: "Interval dimensions do not match.";
+
+		final double t0 = interval.realMin( 0 );
+		final double t1 = interval.realMin( 1 );
+		final double t2 = interval.realMin( 2 );
+
+		final double s0 = interval.realMax( 0 ) - t0;
+		final double s1 = interval.realMax( 1 ) - t1;
+		final double s2 = interval.realMax( 2 ) - t2;
+
+		final double tt0 = a.m00 * t0 + a.m01 * t1 + a.m02 * t2 + a.m03;
+		final double tt1 = a.m10 * t0 + a.m11 * t1 + a.m12 * t2 + a.m13;
+		final double tt2 = a.m20 * t0 + a.m21 * t1 + a.m22 * t2 + a.m23;
+
+		double rMin0 = tt0;
+		double rMax0 = tt0;
+		if ( a.m00 < 0 )
+			rMin0 += s0 * a.m00;
+		else
+			rMax0 += s0 * a.m00;
+		if ( a.m01 < 0 )
+			rMin0 += s1 * a.m01;
+		else
+			rMax0 += s1 * a.m01;
+		if ( a.m02 < 0 )
+			rMin0 += s2 * a.m02;
+		else
+			rMax0 += s2 * a.m02;
+
+		double rMin1 = tt1;
+		double rMax1 = tt1;
+		if ( a.m10 < 0 )
+			rMin1 += s0 * a.m10;
+		else
+			rMax1 += s0 * a.m10;
+		if ( a.m11 < 0 )
+			rMin1 += s1 * a.m11;
+		else
+			rMax1 += s1 * a.m11;
+		if ( a.m12 < 0 )
+			rMin1 += s2 * a.m12;
+		else
+			rMax1 += s2 * a.m12;
+
+		double rMin2 = tt2;
+		double rMax2 = tt2;
+		if ( a.m20 < 0 )
+			rMin2 += s0 * a.m20;
+		else
+			rMax2 += s0 * a.m20;
+		if ( a.m21 < 0 )
+			rMin2 += s1 * a.m21;
+		else
+			rMax2 += s1 * a.m21;
+		if ( a.m22 < 0 )
+			rMin2 += s2 * a.m22;
+		else
+			rMax2 += s2 * a.m22;
+
+		final double[] rMin = new double[ interval.numDimensions() ];
+		final double[] rMax = new double[ rMin.length ];
+		rMin[ 0 ] = rMin0;
+		rMax[ 0 ] = rMax0;
+		rMin[ 1 ] = rMin1;
+		rMax[ 1 ] = rMax1;
+		rMin[ 2 ] = rMin2;
+		rMax[ 2 ] = rMax2;
+		for ( int d = 3; d < rMin.length; ++d )
+		{
+			rMin[ d ] = interval.realMin( d );
+			rMax[ d ] = interval.realMax( d );
+		}
+		return new FinalRealInterval( rMin, rMax );
+	}
+
 	/**
 	 * Calculate the boundary interval of an interval after it has been
 	 * transformed.

--- a/src/test/java/net/imglib2/realtransform/AffineTransform3DBenchmark.java
+++ b/src/test/java/net/imglib2/realtransform/AffineTransform3DBenchmark.java
@@ -33,12 +33,14 @@
  */
 package net.imglib2.realtransform;
 
+import java.util.Random;
 import java.util.concurrent.TimeUnit;
 import net.imglib2.FinalRealInterval;
 import net.imglib2.test.ImgLib2Assert;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Scope;
@@ -55,18 +57,30 @@ import org.openjdk.jmh.runner.options.TimeValue;
 @Fork( 1 )
 public class AffineTransform3DBenchmark
 {
+	public static Random random = new Random( 0 );
+
 	public AffineTransform3D affine;
 
 	public FinalRealInterval interval;
 
-	@Setup
+	@Setup( Level.Iteration )
 	public void allocate()
 	{
+		final double[] min = new double[ 3 ];
+		final double[] max = new double[ 3 ];
+		for ( int d = 0; d < 3; d++ )
+		{
+			final double a = random.nextDouble();
+			final double b = random.nextDouble();
+			min[ d ] = Math.min( a, b );
+			max[ d ] = Math.max( a, b );
+		}
+		interval = new FinalRealInterval( min, max );
+
 		affine = new AffineTransform3D();
-		affine.set( 0.6257181216214484, -0.42700874006027256, 1.7985971795733178, 14.49098566228043,
-				-0.23594150694929406, 0.2738747799215179, 3.865571650972771, 316.97923101552897,
-				-0.5001796987961186, -0.663312458844776, 0.42718951567612307, 483.7819295341877 );
-		interval = new FinalRealInterval( new double[] { -0.5, -0.5, -0.5 }, new double[] { 957.5, 385.5, 43.5 } );
+		for ( int r = 0; r < 3; r++ )
+			for ( int c = 0; c < 4; c++ )
+				affine.set( random.nextDouble(), r, c );
 	}
 
 	@Benchmark

--- a/src/test/java/net/imglib2/realtransform/AffineTransform3DBenchmark.java
+++ b/src/test/java/net/imglib2/realtransform/AffineTransform3DBenchmark.java
@@ -78,15 +78,6 @@ public class AffineTransform3DBenchmark
 		blackhole.consume( i );
 	}
 
-	@Benchmark
-	@BenchmarkMode( Mode.AverageTime )
-	@OutputTimeUnit( TimeUnit.NANOSECONDS )
-	public void estimateBoundsFast( Blackhole blackhole )
-	{
-		FinalRealInterval i = affine.estimateBoundsFast( interval );
-		blackhole.consume( i );
-	}
-
 	public static void main( final String... args ) throws RunnerException
 	{
 		final Options opt = new OptionsBuilder()

--- a/src/test/java/net/imglib2/realtransform/AffineTransform3DBenchmark.java
+++ b/src/test/java/net/imglib2/realtransform/AffineTransform3DBenchmark.java
@@ -1,0 +1,101 @@
+/*
+ * #%L
+ * ImgLib2: a general-purpose, multidimensional image processing library.
+ * %%
+ * Copyright (C) 2009 - 2016 Tobias Pietzsch, Stephan Preibisch, Stephan Saalfeld,
+ * John Bogovic, Albert Cardona, Barry DeZonia, Christian Dietz, Jan Funke,
+ * Aivar Grislis, Jonathan Hale, Grant Harris, Stefan Helfrich, Mark Hiner,
+ * Martin Horn, Steffen Jaensch, Lee Kamentsky, Larry Lindsey, Melissa Linkert,
+ * Mark Longair, Brian Northan, Nick Perry, Curtis Rueden, Johannes Schindelin,
+ * Jean-Yves Tinevez and Michael Zinsmaier.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+package net.imglib2.realtransform;
+
+import java.util.concurrent.TimeUnit;
+import net.imglib2.FinalRealInterval;
+import net.imglib2.test.ImgLib2Assert;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.infra.Blackhole;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import org.openjdk.jmh.runner.options.TimeValue;
+
+@State( Scope.Thread )
+@Fork( 1 )
+public class AffineTransform3DBenchmark
+{
+	public AffineTransform3D affine;
+
+	public FinalRealInterval interval;
+
+	@Setup
+	public void allocate()
+	{
+		affine = new AffineTransform3D();
+		affine.set( 0.6257181216214484, -0.42700874006027256, 1.7985971795733178, 14.49098566228043,
+				-0.23594150694929406, 0.2738747799215179, 3.865571650972771, 316.97923101552897,
+				-0.5001796987961186, -0.663312458844776, 0.42718951567612307, 483.7819295341877 );
+		interval = new FinalRealInterval( new double[] { -0.5, -0.5, -0.5 }, new double[] { 957.5, 385.5, 43.5 } );
+	}
+
+	@Benchmark
+	@BenchmarkMode( Mode.AverageTime )
+	@OutputTimeUnit( TimeUnit.NANOSECONDS )
+	public void estimateBounds( Blackhole blackhole )
+	{
+		FinalRealInterval i = affine.estimateBounds( interval );
+		blackhole.consume( i );
+	}
+
+	@Benchmark
+	@BenchmarkMode( Mode.AverageTime )
+	@OutputTimeUnit( TimeUnit.NANOSECONDS )
+	public void estimateBoundsFast( Blackhole blackhole )
+	{
+		FinalRealInterval i = affine.estimateBoundsFast( interval );
+		blackhole.consume( i );
+	}
+
+	public static void main( final String... args ) throws RunnerException
+	{
+		final Options opt = new OptionsBuilder()
+				.include( AffineTransform3DBenchmark.class.getSimpleName() )
+				.warmupIterations( 4 )
+				.measurementIterations( 8 )
+				.warmupTime( TimeValue.milliseconds( 200 ) )
+				.measurementTime( TimeValue.milliseconds( 200 ) )
+				.build();
+		new Runner( opt ).run();
+	}
+}

--- a/src/test/java/net/imglib2/realtransform/AffineTransform3DTest.java
+++ b/src/test/java/net/imglib2/realtransform/AffineTransform3DTest.java
@@ -37,6 +37,9 @@ import static org.junit.Assert.*;
 
 import java.util.Random;
 
+import net.imglib2.FinalRealInterval;
+import net.imglib2.test.ImgLib2Assert;
+import net.imglib2.util.Intervals;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -56,6 +59,18 @@ public class AffineTransform3DTest
 	public void setUp() throws Exception
 	{
 		 rnd.setSeed( 0 );
+	}
+
+	@Test
+	public void testEstimateBoundsFast()
+	{
+		final AffineTransform3D affine = new AffineTransform3D();
+		affine.set( 0.6257181216214484, -0.42700874006027256, 1.7985971795733178, 14.49098566228043,
+				-0.23594150694929406, 0.2738747799215179, 3.865571650972771, 316.97923101552897,
+				-0.5001796987961186, -0.663312458844776, 0.42718951567612307, 483.7819295341877 );
+		final FinalRealInterval interval = new FinalRealInterval( new double[] { -0.5, -0.5, -0.5 }, new double[] { 957.5, 385.5, 43.5 } );
+
+		ImgLib2Assert.assertIntervalEquals( affine.estimateBounds( interval ), affine.estimateBoundsFast( interval ), 0.0000001 );
 	}
 
 	@Test

--- a/src/test/java/net/imglib2/realtransform/AffineTransform3DTest.java
+++ b/src/test/java/net/imglib2/realtransform/AffineTransform3DTest.java
@@ -37,9 +37,6 @@ import static org.junit.Assert.*;
 
 import java.util.Random;
 
-import net.imglib2.FinalRealInterval;
-import net.imglib2.test.ImgLib2Assert;
-import net.imglib2.util.Intervals;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -59,18 +56,6 @@ public class AffineTransform3DTest
 	public void setUp() throws Exception
 	{
 		 rnd.setSeed( 0 );
-	}
-
-	@Test
-	public void testEstimateBoundsFast()
-	{
-		final AffineTransform3D affine = new AffineTransform3D();
-		affine.set( 0.6257181216214484, -0.42700874006027256, 1.7985971795733178, 14.49098566228043,
-				-0.23594150694929406, 0.2738747799215179, 3.865571650972771, 316.97923101552897,
-				-0.5001796987961186, -0.663312458844776, 0.42718951567612307, 483.7819295341877 );
-		final FinalRealInterval interval = new FinalRealInterval( new double[] { -0.5, -0.5, -0.5 }, new double[] { 957.5, 385.5, 43.5 } );
-
-		ImgLib2Assert.assertIntervalEquals( affine.estimateBounds( interval ), affine.estimateBoundsFast( interval ), 0.0000001 );
 	}
 
 	@Test


### PR DESCRIPTION
This PR replaces `AffineTransform3D.estimateBounds(RealInterval)` with a more efficient algorithm (O(n^2) in number of dimensions instead of O(2^n)).

Intermediate commits have a test comparing old vs new version and benchmarks. (So this PR should probably be squashed.)


The old algorithm took the corners of the input interval, passed them through the transform, then computed the bounding box of the transformed points.


The idea of the new algorithm is along these lines:

We can easily write an affine transform `S` that transforms the unit cube (min at origin, side length one)  to the input interval.
Then we have to find the bounding box of the transformed unit cube via `this * S`.

Then ignore the translation part. That can be easily applied afterwards, shifting the estimated bounding box. So we only look at the 3x3 rotation/scale/shear matrix of `this * S`. Let's call this 3x3 matrix `A`. Because `S` is a diagonal matrix, `A` simply consists of scaled columns of `this`.

Now: The origin transforms to the origin. The unit vectors along each axis transform to the columns of `A`.
Because `this` is a linear transform, the transformed corners are the sum of all combinations of 0..3 of the transformed unit vectors. The bounding box is found without explicitly computing these corners, by looking at each dimension individually.
For example, for the minimum in X: origin is transformed to origin, so minimum can not be > 0. To get it lower than 0, we take those transformed unit vectors that have X<0. Summing over these 0..3 values X<0 gives the minimum in X. And analogous for max X and other dimensions.

Finally, add the translation part.
