### PR TITLE
Fix RealViewsSimplifyUtils.java wrong argument order in ScaleAndTranslation constructor

### DIFF
--- a/src/main/java/net/imglib2/realtransform/RealViewsSimplifyUtils.java
+++ b/src/main/java/net/imglib2/realtransform/RealViewsSimplifyUtils.java
@@ -259,7 +259,7 @@ public class RealViewsSimplifyUtils
 				s[ d ] = affineGet.get( d, d );
 			}
 
-			return new ScaleAndTranslation( t, s );
+			return new ScaleAndTranslation( s, t );
 
 		}
 		return ( AffineGet ) affineGet.copy();


### PR DESCRIPTION
Swaps argument in ScaleAndTranslation constructor: it should be scales first and translations second.

I've noticed this because I'm trying to improve the perfs of some bigdataviewer-playground functionality. By chance I went into this branch and I obtained weird results. In debugging I found this inversion in constructor arguments. I did not checked extensively whether there was other similar inversion in the repo.

