### PR TITLE
Add Spherical curvature distortion transformation

### DIFF
--- a/src/main/java/net/imglib2/realtransform/distortion/SphericalCurvatureDistortionTransform.java
+++ b/src/main/java/net/imglib2/realtransform/distortion/SphericalCurvatureDistortionTransform.java
@@ -1,0 +1,155 @@
+package net.imglib2.realtransform.distortion;
+
+import net.imglib2.RealLocalizable;
+import net.imglib2.RealPositionable;
+import net.imglib2.realtransform.InvertibleRealTransform;
+
+/**
+ * Applies spherical field curvature distortion along the axial dimension.
+ * <p>
+ * The axial offset follows the formula: z' = z + (R - √(R² - r²)), where R is the radius of curvature
+ * and r is the distance from the optical axis.
+ * <p>
+ * Note: This transform is only invertible for points within radius R from the optical axis.
+ * Points at radius r > R will produce NaN values.
+ */
+public class SphericalCurvatureDistortionTransform implements InvertibleRealTransform
+{
+	private final int numDimensions;
+
+	private final int axialDimension;
+
+	private final double R;
+
+	private final double sign;
+
+	/**
+	 * Creates a spherical curvature distortion transform.
+	 *
+	 * @param numDimensions number of dimensions
+	 * @param axialDimension the dimension index of the optical axis where curvature is applied
+	 * @param R radius of curvature
+	 */
+	public SphericalCurvatureDistortionTransform( final int numDimensions, final int axialDimension, double R )
+	{
+		this(numDimensions, axialDimension, R, 1.0);
+	}
+
+	private SphericalCurvatureDistortionTransform( final int numDimensions, final int axialDimension, double R, double sign)
+	{
+		this.numDimensions = numDimensions;
+		this.axialDimension = axialDimension;
+		this.R = R;
+		this.sign = sign;
+	}
+
+	@Override
+	public int numSourceDimensions()
+	{
+		return numDimensions;
+	}
+
+	@Override
+	public int numTargetDimensions()
+	{
+		return numDimensions;
+	}
+
+	@Override
+	public void apply( double[] source, double[] target )
+	{
+		for ( int i = 0; i < numDimensions; i++ )
+		{
+			if ( i == axialDimension )
+				target[ i ] = source[ i ] + sign * axialOffset( squaredRadius( source ) );
+			else
+				target[ i ] = source[ i ];
+		}
+	}
+
+	private void apply( double s, double[] source, double[] target )
+	{
+		for ( int i = 0; i < numDimensions; i++ )
+		{
+			if ( i == axialDimension )
+				target[ i ] = source[ i ] + s * sign * axialOffset( squaredRadius( source ) );
+			else
+				target[ i ] = source[ i ];
+		}
+	}
+
+	@Override
+	public void apply( RealLocalizable source, RealPositionable target )
+	{
+
+		for ( int i = 0; i < numDimensions; i++ )
+		{
+			if ( i == axialDimension )
+				target.setPosition( source.getDoublePosition( i ) + sign * axialOffset( squaredRadius( source ) ), i );
+			else
+				target.setPosition( source.getDoublePosition( i ), i );
+		}
+	}
+
+	private void apply( double s, RealLocalizable source, RealPositionable target )
+	{
+
+		for ( int i = 0; i < numDimensions; i++ )
+		{
+			if ( i == axialDimension )
+				target.setPosition( source.getDoublePosition( i ) + s * sign * axialOffset( squaredRadius( source ) ), i );
+			else
+				target.setPosition( source.getDoublePosition( i ), i );
+		}
+	}
+
+	@Override
+	public void applyInverse( double[] source, double[] target )
+	{
+		apply( -1, target, source );
+	}
+
+	@Override
+	public void applyInverse( RealPositionable source, RealLocalizable target )
+	{
+		apply( -1, target, source );
+	}
+
+	@Override
+	public SphericalCurvatureDistortionTransform copy()
+	{
+		return new SphericalCurvatureDistortionTransform( numDimensions, axialDimension, R, sign );
+	}
+
+	@Override
+	public InvertibleRealTransform inverse()
+	{
+		return new SphericalCurvatureDistortionTransform( numDimensions, axialDimension, R, -1 * sign );
+	}
+
+	private double squaredRadius( double[] position )
+	{
+		double r = 0;
+		for ( int i = 0; i < position.length; i++ )
+			if ( i != axialDimension )
+				r += position[ i ] * position[ i ];
+
+		return r;
+	}
+
+	private double squaredRadius( RealLocalizable position )
+	{
+		double r = 0;
+		for ( int i = 0; i < position.numDimensions(); i++ )
+			if ( i != axialDimension )
+				r += position.getDoublePosition( i ) * position.getDoublePosition( i );
+
+		return r;
+	}
+
+	private double axialOffset( double r2 )
+	{
+		return R - Math.sqrt( ( R * R ) - r2 );
+	}
+
+}

--- a/src/main/java/net/imglib2/realtransform/distortion/SphericalCurvatureDistortionTransform.java
+++ b/src/main/java/net/imglib2/realtransform/distortion/SphericalCurvatureDistortionTransform.java
@@ -11,7 +11,7 @@ import net.imglib2.realtransform.InvertibleRealTransform;
  * and r is the distance from the optical axis.
  * <p>
  * Note: This transform is only invertible for points within radius R from the optical axis.
- * Points at radius r > R will produce NaN values.
+ * Points at radius r greater than R will produce NaN values.
  */
 public class SphericalCurvatureDistortionTransform implements InvertibleRealTransform
 {

--- a/src/test/java/net/imglib2/realtransform/distortion/SphericalCurvatureDistortionTest.java
+++ b/src/test/java/net/imglib2/realtransform/distortion/SphericalCurvatureDistortionTest.java
@@ -1,0 +1,23 @@
+package net.imglib2.realtransform.distortion;
+
+import org.junit.Test;
+
+import net.imglib2.FinalRealInterval;
+import net.imglib2.realtransform.IterableInverseTests;
+import net.imglib2.util.Intervals;
+
+public class SphericalCurvatureDistortionTest
+{
+	private static final double EPS = 1E-6;
+
+	@Test
+	public void inverseTest() throws Exception
+	{
+		final SphericalCurvatureDistortionTransform tform = new SphericalCurvatureDistortionTransform( 3, 2, 1000.0 );
+		final FinalRealInterval interval = Intervals.createMinMaxReal( -1.0, -1.0, -1.0, 2.01, 2.01, 2.01 );
+		final double[] step = new double[] { 0.1, 0.1, 0.1 };
+
+		IterableInverseTests.inverseTransformTestHelper( tform, interval, step, EPS );
+	}
+
+}


### PR DESCRIPTION
This PR adds a `SphericalCurvatureDistortionTransform` that can serve to model a particular kind of distortion in optical systems.

This example code:
```java
final int numDimensions = 2;
final int dimensionToTransform = 1;
final double radiusOfCurvature = 250;
final SphericalCurvatureDistortionTransform tform = new SphericalCurvatureDistortionTransform(
		numDimensions,
		dimensionToTransform,
		radiusOfCurvature);

final ArrayImg<UnsignedByteType, ByteArray> img = ArrayImgs.unsignedBytes(256,256);
img.view().interval(Intervals.createMinMax(36,128,164,164)).forEach( x -> x.set(255) );

final RandomAccessibleIntervalView<UnsignedByteType> imgTform = RealViews.transform(
	img.view()
		.extend(Extension.zero())
		.interpolate(Interpolation.nLinear()),
	tform).realView().raster().view().interval(img);

ImageJFunctions.show(img, "toy tile");
ImageJFunctions.show(imgTform, "toy tile distorted");
```

produces this output:
<img width="528" height="318" alt="image" src="https://github.com/user-attachments/assets/2285746e-812b-466f-9a29-52a7638beefb" />
