### PR TITLE
Fix: axis permutations silently erased by transform simplification

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@
 
 # Maven #
 /target/
+
+# IntelliJ IDEA #
+/.idea/

--- a/src/main/java/net/imglib2/realtransform/RealViewsSimplifyUtils.java
+++ b/src/main/java/net/imglib2/realtransform/RealViewsSimplifyUtils.java
@@ -108,7 +108,9 @@ public class RealViewsSimplifyUtils
 			for ( int c = 0; c < n + 1; ++c )
 			{
 				final double val = affineGet.get( r, c );
-				if ( val != 0.0 && ( ( r == c && val != 1.0 ) || ( c != n && val != 1.0 ) ) ) { return false; }
+				if ( c == n ) { continue; } // translation column: any value allowed
+				if ( r == c ) { if ( val != 1.0 ) { return false; } } // diagonal must be 1
+				else if ( val != 0.0 ) { return false; } // off-diagonal must be 0
 			}
 		}
 

--- a/src/test/java/net/imglib2/realtransform/RealViewsSimplificationsTest.java
+++ b/src/test/java/net/imglib2/realtransform/RealViewsSimplificationsTest.java
@@ -85,6 +85,19 @@ public class RealViewsSimplificationsTest
 			0.0, 0.0, 0.0, 1.0, 10.5,
 	}, 4 );
 
+	// Pure axis permutation (X <-> Y swap) plus translation. NOT a translation.
+	private static final AffineGet PERMUTATION2D = create( new double[] {
+			0.0, 1.0, 2.0,
+			1.0, 0.0, 5.5
+	}, 2 );
+
+	// Pure axis permutation (Y <-> Z swap) plus translation. NOT a translation.
+	private static final AffineGet PERMUTATION3D = create( new double[] {
+			1.0, 0.0, 0.0, 2.0,
+			0.0, 0.0, 1.0, 5.5,
+			0.0, 1.0, 0.0, 7.5
+	}, 3 );
+
 	private static final AffineGet SCALE2D = create( new double[] {
 			2.0, 0.0, 0.0,
 			0.0, 1.0, 0.0
@@ -208,6 +221,35 @@ public class RealViewsSimplificationsTest
 		Assert.assertFalse( RealViewsSimplifyUtils.isExlusiveTranslation( SCALE2D ) );
 		Assert.assertFalse( RealViewsSimplifyUtils.isExlusiveTranslation( SCALE3D ) );
 		Assert.assertFalse( RealViewsSimplifyUtils.isExlusiveTranslation( SCALE4D ) );
+
+		// An axis permutation is not a pure translation.
+		Assert.assertFalse( RealViewsSimplifyUtils.isExlusiveTranslation( PERMUTATION2D ) );
+		Assert.assertFalse( RealViewsSimplifyUtils.isExlusiveTranslation( PERMUTATION3D ) );
+	}
+
+	@Test
+	public void testSimplifyingPermutationIsNotTranslation()
+	{
+		// A permutation must not be collapsed to a Translation: that would silently
+		// drop the axis swap. It should fall through to a generic affine.
+		Assert.assertFalse( RealViewsSimplifyUtils.simplifyRealTransform( PERMUTATION2D ) instanceof Translation );
+		Assert.assertFalse( RealViewsSimplifyUtils.simplifyRealTransform( PERMUTATION2D ) instanceof Translation2D );
+		Assert.assertFalse( RealViewsSimplifyUtils.simplifyRealTransform( PERMUTATION3D ) instanceof Translation );
+		Assert.assertFalse( RealViewsSimplifyUtils.simplifyRealTransform( PERMUTATION3D ) instanceof Translation3D );
+	}
+
+	@Test
+	public void testSimplifyingPermutationPreservesMatrix()
+	{
+		// Simplifying a permutation must preserve the full matrix, not just the
+		// last (translation) column.
+		final RealTransform simplified2D = RealViewsSimplifyUtils.simplifyRealTransform( PERMUTATION2D );
+		Assert.assertArrayEquals( PERMUTATION2D.getRowPackedCopy(),
+				( ( AffineGet ) simplified2D ).getRowPackedCopy(), 0.0 );
+
+		final RealTransform simplified3D = RealViewsSimplifyUtils.simplifyRealTransform( PERMUTATION3D );
+		Assert.assertArrayEquals( PERMUTATION3D.getRowPackedCopy(),
+				( ( AffineGet ) simplified3D ).getRowPackedCopy(), 0.0 );
 	}
 
 	@Test


### PR DESCRIPTION
Fixes https://github.com/imglib/imglib2-realtransform/issues/52

## Summary

`RealViewsSimplifyUtils.isExlusiveTranslation` misclassified axis-permutation
matrices as pure translations. `simplifyAffineGet` then rebuilt them from the
translation column only, silently discarding the permutation: shapes stayed
intact and the translation was roughly right, but the orientation was lost.

## Root cause

The classifier coupled the off-diagonal test to `val != 1.0`:

```java
if ( val != 0.0 && ( ( r == c && val != 1.0 ) || ( c != n && val != 1.0 ) ) ) return false;
```

For an off-diagonal entry (`r != c`, `c < n`) equal to `1.0`, neither clause
fires, so it is accepted. The diagonal rule ("must be 1") was wrongly applied to
every in-matrix entry, instead of "off-diagonal must be 0". A concrete Y/Z swap:

```
[ 1 0 0 | tx ]
[ 0 0 1 | ty ]   <- m12 = 1, off-diagonal, wrongly accepted
[ 0 1 0 | tz ]   <- m21 = 1, off-diagonal, wrongly accepted
```

passed as a pure translation. A tiny rotation (e.g. 0.5 deg) turns the exact
`1.0` entries into `0.9999...`, which trips `val != 1.0` and accidentally masks
the bug -- explaining why a small "nudge" appeared to fix it.

## Fix

Replace the conflated condition with the three explicit rules:

```java
if ( c == n ) { continue; }                            // translation column: any value
if ( r == c ) { if ( val != 1.0 ) return false; }      // diagonal must be 1
else if ( val != 0.0 ) return false;                   // off-diagonal must be 0
```

Permutations now fail classification and fall through to the lossless generic
affine copy. No information is dropped.

## Scope

The sibling classifiers (`isExclusiveScale`, `isExclusiveScaleAndTranslation`)
were reviewed and are not affected: both already disqualify any non-zero
off-diagonal entry regardless of value. `boundingInterval`/`estimateBounds` use
the full matrix and handle off-diagonal terms correctly. This was the only
erasure path.

The public method name `isExlusiveTranslation` (sic) is kept unchanged to avoid
breaking API compatibility.

## Tests

Added to `RealViewsSimplificationsTest` (committed first, red before the fix):

- `isExlusiveTranslation` must reject `PERMUTATION2D` / `PERMUTATION3D`
- simplifying a permutation must not yield a `Translation*`
- simplifying a permutation must preserve the full matrix

Full module test suite passes after the fix.